### PR TITLE
Remove "consider debugging" step in CI

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -73,10 +73,6 @@ jobs:
       - name: add osd
         run:  ./scripts/cephadm-test.sh add_osds
 
-      - name: consider debugging
-        uses: lhotari/action-upterm@v1
-        if: failure()
-
   RookTest:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
The "consider debugging" step stalls the GitHub runner, causing it to take 6 hours to run.

![debug](https://user-images.githubusercontent.com/115640263/219671713-4f7fb0c8-021f-46a0-9967-3ae2184a25cf.png)

From: https://github.com/canonical/ceph-containers/actions/runs/4201530535/jobs/7288716680

The `canonical` organization is currently reaching the maximum concurrent GitHub runner limit: https://chat.canonical.com/canonical/pl/p7qq3g4se7brjchzszyoiqfxqr