### PR TITLE
Remove dockerhub login

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -12,12 +12,6 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
       
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38


### PR DESCRIPTION
Login to dockerhub is not necessary to upload assets to ghcr