### PR TITLE
Added workflow to publish temporary OCI releases from PR

### DIFF
--- a/.github/workflows/publish_temp_image.yaml
+++ b/.github/workflows/publish_temp_image.yaml
@@ -1,20 +1,31 @@
-name: Publish Ceph ROCK
+name: Publish Temporary ROCK
 
-on:
-  push:
-    branches: ['main']
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+on: 
+  issue_comment:
+    types: [created]
 
 jobs:
-  push_to_registry:
-    name: Push Ceph ROCK to GHCR
+  pr_commented:
+    name: PR comment
+    # Run only if the comment is on a pull request and contains the keyword.
+    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/publish') 
     runs-on: ubuntu-latest
     outputs:
       rock: ${{ steps.rockcraft.outputs.rock }}
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
+      - run: |
+          echo Publishing container image for PR# $NUMBER
+        env:
+          NUMBER: ${{ github.event.issue.number }}
+
+      # Get branch from PR as issue_comment references the main branch by default.
+      - uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
+      - uses: actions/checkout@v3
+        if: success()
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
 
       - name: login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -28,6 +39,9 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ghcr.io/canonical/ceph
+          # Create OCI tag using the PR.
+          tags: |
+            type=ref,event=pr
 
       - name: Prepare Rock
         uses: canonical/craft-actions/rockcraft-pack@main


### PR DESCRIPTION
Ceph ROCKs may need temporary releases to be provided as HOT-fixes. This workflow allows users to publish PR tagged ROCKs to GHCR so that they can be consumed before actually being merged into the repository. This also helps testing since tools (like cephadm and rook) need registry references to deploy ceph clusters.