### PR TITLE
Push trigger tests only for release branches

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,9 +1,14 @@
 name: Canary image testing
 
 on:
+  # Run test on each "PUSH" to release branches only.
   push:
+    branches:
+      - 'main'
+      - 'stable/*'
+  # Run test on all PRs.
   pull_request:
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually for any internal branch from the Actions tab.
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Edit currently a push to all internal branches triggers a canary image testing workflow, for non release branches each PR runs the same tests so can be skipped on push.