### PR TITLE
Refined Release tagging

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -19,13 +19,6 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Get Branch
-        id: branch
-        run: |
-          raw=$(git branch -r --contains ${{ github.ref }})
-          branch=${raw/origin\/}
-          echo "::set-output name=name::$branch"
-
       - name: Install deps and clean legacy rules.
         run: |
           sudo snap install lxd
@@ -41,10 +34,9 @@ jobs:
           PKG_VER_STR=$(sudo rockcraft pull pkg_info -v &>  >(grep "Version"))
           PKG_VER=$(cut -d' ' -f3 <<< $PKG_VER_STR)
           CEPH_VER=$(cut -d'-' -f1 <<< $PKG_VER)
-          DEB_VER=$(cut -d'-' -f2 <<< $PKG_VER)
           sed -i "/version:/c\version: $CEPH_VER" rockcraft.yaml
           echo "::set-output name=ceph_version::$CEPH_VER"
-          echo "::set-output name=deb_version::$DEB_VER"
+          echo "::set-output name=pkg_version::$PKG_VER"
 
       - name: login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -60,10 +52,9 @@ jobs:
           images: ghcr.io/canonical/ceph
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=${{ steps.versioning.outputs.deb_version }}
+            type=raw,value=${{ steps.versioning.outputs.pkg_version }}
             type=raw,value=quincy,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '17') }}
             type=raw,value=reef,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '18') }}
-            type=raw,value=dev,enable=${{ steps.branch.outputs.name == 'main' }}
 
       - name: Prepare Rock
         uses: canonical/craft-actions/rockcraft-pack@main


### PR DESCRIPTION
Once this PR is merged, we need to test the tagging by git tagging the any commit as `v17.2.6-beta`. The expected tags are:
1. v17.2.6-beta
2. v17.2.6-deb-ver
3. quincy