### PR TITLE
Added Install hub cmd step to publish workflow.

### DIFF
--- a/.github/workflows/publish_hotfix.yaml
+++ b/.github/workflows/publish_hotfix.yaml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install hub
+        run: sudo apt-get update && sudo apt-get install -y hub
+
       - name: Checkout Pull Request
         run: hub pr checkout ${{ github.event.pull_request.number }}
         env:


### PR DESCRIPTION
As of October 2023, hub cmd is not available on github runner images out of the box, see reference.

Reference:
https://github.com/actions/runner-images/issues/8362