### PR TITLE
Review README and HACKING files

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -164,7 +164,7 @@ python3 test/deploy.py delete model-88HJ.json
 > **Note:**
 You can also use the script to deploy (experimentally) on a LXD container
 (rather than a VM) using `--container 1`. This can be interesting when KVM
-support is note available on the machine. However, this is not recommended. For
+support is not available on the machine. However, this is not recommended. For
 detailed info on script usage use:
 
 ```

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,57 +1,98 @@
 # Ceph ROCK Hacking Guide
-The aim of this document is to enable new developers/users get familiarised with the build tools and Ceph ROCK repository so that they can build and contribute to [Ceph-Containers](https://github.com/canonical/ceph-containers).
+
+The aim of this document is to familiarise developers with the build tools and
+Ceph ROCK registry so that they can contribute to
+[Ceph-Containers](https://github.com/canonical/ceph-containers).
 
 ## Table of Contents
+
 1. [Introduction to ROCKs](#introduction-to-rocks)
 2. [Tools](#tools)
 3. [References](#references)
-4. [Build Guide](#build-guide)
-6. [Uisng Ceph ROCKs](#using-ceph-rocks)
+4. [Build guide](#build-guide)
+6. [Using Ceph ROCKs](#using-ceph-rocks)
 
 ## Introduction to ROCKs
-> A [ROCK](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/) is an [OCI](https://en.wikipedia.org/wiki/Open_Container_Initiative) compliant container archive built on top of Ubuntu LTS releases. ROCKs are interoperable with all OCI-compliant tools and platforms.
 
-The Ceph ROCK packages all the required ceph-binaries along with utilities, [kubectl](https://kubernetes.io/docs/reference/kubectl/), [confd](https://github.com/kelseyhightower/confd), some configuration files and scripts.
+A
+[ROCK](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/)
+is an [OCI](https://en.wikipedia.org/wiki/Open_Container_Initiative) compliant
+container archive built on top of an Ubuntu LTS release. ROCKs are interoperable
+with all OCI-compliant tools and platforms.
+
+A Ceph ROCK contains:
+
+* required Ceph binaries
+* [kubectl](https://kubernetes.io/docs/reference/kubectl/) and [confd](https://github.com/kelseyhightower/confd) utilities
+* configuration files and scripts
 
 ## Tools
-ROCKs are built using a snap called [rockcraft](https://github.com/canonical/rockcraft). It uses [lxd](https://github.com/canonical/lxd) to pull dependencies and build an artefact completely isolated from the host system. This makes it easier for developers to work on ROCKs without polluting their host system with unwanted dependencies.
-You can install rockcraft and lxd using snap tool.
-```bash
+
+ROCKs are built using [Rockcraft](https://github.com/canonical/rockcraft). It
+uses [LXD](https://github.com/canonical/lxd) to pull dependencies and build an
+artefact completely isolated from the host system. This makes it easier for
+developers to work on ROCKs without polluting their host system with unwanted
+dependencies.
+
+You can install Rockcraft and LXD in this way:
+
+``` text
 sudo snap install rockcraft --classic
 sudo snap install lxd
 ```
 
-> **_NOTE:_**
-For a detailed how-to-use rockcraft tool guide, check-out [ROCK Docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/)
+> **Note:**
+See the [Rockcraft
+documentation](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/)
+for in-depth guidance on using the `rockcraft` tool.
 
 ## References
-The `rockcraft` tool uses a declarative file called `rockcraft.yaml` as the blueprint to prepare the artefact. Below is a brief description of all the `parts` that make the Ceph ROCK.
+
+The `rockcraft` tool uses a declarative file called `rockcraft.yaml` as the
+blueprint to prepare the artefact. Below is a brief description of all the
+`parts` that make up the Ceph ROCK.
 
 ### Parts
+
 1. **[ceph](rockcraft.yaml#L26)**
 
-    Contains the related ceph and utility packages that are fetched from the ubuntu package repository for building this part.
+    Lists the necessary Ceph and utility packages that are fetched from the
+    Ubuntu package repository.
 
 2. **[confd](rockcraft.yaml#L76)**
 
-    Confd is a configuration management system that can actively watch a consistent kv store like etcd and change config files based on templates. Used for rook based deployments.
+    Confd is a configuration management system that can actively watch a
+    consistent kv store like etcd and change config files based on templates.
+    Used for Rook based deployments.
 
 3. **[kubectl](rockcraft.yaml#L86)**
 
-    Kubernetes provides a command line tool for communicating with the cluster's control plane, using the Kubernetes API. This tool is named `kubectl`. Kubectl is built using [kubectl.go](kubectl/kubectl.go) and `go` snap.
+    Kubernetes provides a command line tool for communicating with the
+    cluster's control plane, using the Kubernetes API. This tool is named
+    `kubectl` and is built using [kubectl.go](kubectl/kubectl.go) and the `go`
+    snap.
 
 4. **[local-files](rockcraft.yaml#L93)**
 
-    Contains bash scripts, configuration files (s3cfg, ceph.defaults, confd templates, etc) that go in the artefact.
+    Contains Bash scripts, configuration files (s3cfg, ceph.defaults, confd
+    templates, etc) that go in the artefact.
 
 5. **[ceph-container-service](rockcraft.yaml#L19)**
 
-    ROCKs use [pebble](https://github.com/canonical/pebble) as the official entrypoint of the OCI artefact. `ceph-container-service` is the pebble definiton of the entrypoint to the ROCK. However, orchestration tools like [Rook](https://rook.io/) and [Cephadm](https://docs.ceph.com/en/latest/cephadm/) don't rely on the configured entrypoint and override it when spawning containers. Hence, the pebble entrypoint is an experimental feature that has not been tested for production deployments.
+    ROCKs use [Pebble](https://github.com/canonical/pebble) as the official
+    entrypoint of the OCI artefact. `ceph-container-service` is the Pebble
+    definition of the entrypoint to the ROCK. However, orchestration tools like
+    [Rook](https://rook.io/) and
+    [Cephadm](https://docs.ceph.com/en/latest/cephadm/) do not rely on the
+    configured entrypoint and override it when spawning containers. Hence, the
+    Pebble entrypoint is an experimental feature that has not been tested for
+    production deployments.
 
+## Build guide
 
-## Build Guide
-Building Ceph ROCK is as easy as a snap!
-```bash
+Here is a summary of how to build a Ceph ROCK:
+
+``` text
 rockcraft -v
 ...
 Starting Rockcraft 0.0.1.dev1
@@ -64,59 +105,74 @@ Exporting to OCI archive
 Exported to OCI archive 'ceph_0.1_amd64.rock'
 ```
 
-The newly created .rock artefact can be loaded into docker for subsequent operations using skopeo as:
-```bash
+The newly created `.rock` artefact can be loaded into docker for subsequent
+operations using `skopeo` as:
+
+``` text
 sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:ceph_0.1_amd64.rock docker-daemon:canonical/ceph:latest
 Getting image source signatures
-Copying blob 3153aa388d02 done  
-Copying blob e3162b5ec315 done  
-Copying blob 9131ac168a8b done  
-Copying blob 0e56abe5b4e6 done  
-Copying config 4d47f598e7 done  
+Copying blob 3153aa388d02 done
+Copying blob e3162b5ec315 done
+Copying blob 9131ac168a8b done
+Copying blob 0e56abe5b4e6 done
+Copying config 4d47f598e7 done
 Writing manifest to image destination
 Storing signatures
 ```
 
 All images available locally can be checked through:
-```bash
+
+``` text
 sudo docker images
 REPOSITORY         TAG          IMAGE ID       CREATED       SIZE
 canonical/ceph     latest       4d47f598e7ef   4 hours ago   1.51GB
 ```
 
-## Automated local deployments using cephadm and lxd
+## Automated local deployments using cephadm and LXD
 
-We also provide a [python3 script](test/deploy.py) which can deploy a single node ceph cluster for you to tinker with using our image, cephadm and lxd. For this to work the host should have lxd snap installed and initialised.
+We also provide a [python3 script](test/deploy.py) which can deploy a single
+node ceph cluster for you to tinker with using our image, cephadm and lxd. For
+this to work the host should have lxd snap installed and initialised.
 
 ```
-$ sudo snap install lxd
-$ lxd init --auto
+sudo snap install lxd
+lxd init --auto
 ```
 
-### Script Usage:
-1.) Use Script to deploy a custom image:
+### Script usage:
+
+1. Use a script to deploy a custom image:
+
 ```
 python3 test/deploy.py image <qualified_image_name>
 ```
-> **_NOTE:_**
-<qualified_image_name> can be a reference to a container image hosted on any public container registry.
-For Example:
+
+> **Note:**
+<qualified_image_name> can be a reference to a container image hosted on any
+public container registry. For Example:
+
 ```
-$ python3 test/deploy.py image ghcr.io/canonical/ceph:main
+python3 test/deploy.py image ghcr.io/canonical/ceph:main
 ```
-2.) Use Script to clean a deployment (using script generated model file):
+
+2. Use a script to clean a deployment (using script-generated model file):
+
 ```
 python3 test/deploy.py delete model-88HJ.json
 ```
 
-> **_NOTE:_**
-You can also use the script to deploy (experimentally) on a LXD container (rather than a VM) using '--container 1', this can be intersting when no KVM support is available on the machine. However, this is not recommended.
-For detailed info on script usage use:
+> **Note:**
+You can also use the script to deploy (experimentally) on a LXD container
+(rather than a VM) using '--container 1', this can be interesting when no KVM
+support is available on the machine. However, this is not recommended. For
+detailed info on script usage use:
+
 ```
 python3 test/deploy.py --help
 ```
 
-VM prepared by Script: 
+VM prepared by a script:
+
 ```
 ubuntu@lxdhost:~$ lxc ls
 +------------------+---------+------------------------+-------------------------------------------------+-----------------+-----------+
@@ -125,26 +181,26 @@ ubuntu@lxdhost:~$ lxc ls
 | ubuntu-ceph-O8HV | RUNNING | 172.17.0.1 (docker0)   | fd42:a569:86fc:7cd5:216:3eff:fea9:5b45 (enp5s0) | VIRTUAL-MACHINE | 0         |
 |                  |         | 10.159.51.242 (enp5s0) |                                                 |                 |           |
 +------------------+---------+------------------------+-------------------------------------------------+-----------------+-----------+
-ubuntu@lxdhost:~$ lxc shell ubuntu-ceph-O8HV 
+
+ubuntu@lxdhost:~$ lxc shell ubuntu-ceph-O8HV
+
 root@ubuntu-ceph-O8HV:~# cephadm shell -- ceph status
   cluster:
     id:     0506c10c-97e1-11ed-82fe-00163ea95b45
     health: HEALTH_OK
- 
+
   services:
     mon: 1 daemons, quorum ubuntu-ceph-O8HV (age 9m)
     mgr: ubuntu-ceph-O8HV.eumeve(active, since 5m)
     osd: 3 osds: 3 up (since 3m), 3 in (since 4m)
- 
+
   data:
     pools:   1 pools, 1 pgs
     objects: 2 objects, 577 KiB
     usage:   64 MiB used, 30 GiB / 30 GiB avail
     pgs:     1 active+clean
- 
+
   progress:
     Updating prometheus deployment (+1 -> 1) (0s)
-      [............................] 
- 
-root@ubuntu-ceph-O8HV:~#
+      [............................]
 ```

--- a/HACKING.md
+++ b/HACKING.md
@@ -131,7 +131,7 @@ canonical/ceph     latest       4d47f598e7ef   4 hours ago   1.51GB
 ## Automated local deployments using cephadm and LXD
 
 We also provide a [python3 script](test/deploy.py) which can deploy a single
-node ceph cluster for you to tinker with using our image, cephadm and lxd. For
+node Ceph cluster for you to tinker with using our image, cephadm, and LXD. For
 this to work the host should have lxd snap installed and initialised.
 
 ```
@@ -163,8 +163,8 @@ python3 test/deploy.py delete model-88HJ.json
 
 > **Note:**
 You can also use the script to deploy (experimentally) on a LXD container
-(rather than a VM) using '--container 1', this can be interesting when no KVM
-support is available on the machine. However, this is not recommended. For
+(rather than a VM) using `--container 1`. This can be interesting when KVM
+support is note available on the machine. However, this is not recommended. For
 detailed info on script usage use:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,33 +1,58 @@
 # Ceph ROCKs
-Home to Ubuntu based Ceph [OCI](https://en.wikipedia.org/wiki/Open_Container_Initiative) Images.
 
-## What on EARTH is a ROCK ?
-[ROCKs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/#rocks-explanation) are a new generation of secure, stable and OCI-compliant container images, based on Ubuntu LTS releases. They are interoperable with all OCI compliant tools. For enthusiasts, we recommend checking out our [Hacking Guide](HACKING.md)
+Home to Ubuntu based Ceph [OCI][wikipedia-oci] images.
 
-## How to download a pre-built image?
-Visit our [Packages](https://github.com/canonical/ceph-containers/pkgs/container/ceph) page which includes instructions to install images, and also documents image versions and hashes.
+## What is a ROCK ?
+
+[ROCKs][definition-rocks] are a new generation of secure, stable, and
+OCI-compliant container images, based on Ubuntu LTS releases. They are
+interoperable with all OCI compliant tools. For enthusiasts, we recommend
+checking out our [Hacking Guide](HACKING.md).
 
 ## Using Ceph ROCKs
-The Ceph ROCK available at the [GH Container Repository](https://github.com/canonical/ceph-containers/pkgs/container/ceph) can be used with popular containerised-ceph deployment tools like:
-1. [Cephadm](https://discourse.ubuntu.com/t/using-cephadm-to-deploy-custom-ubuntu-ceph-images-in-a-containerised-manner/)
-2. [Rook](https://discourse.ubuntu.com/t/deploying-ceph-with-rook/)
 
-## What features are supported ?
+Ceph ROCKs are available via our [GitHub Packages Container
+registry][github-ceph-containers-registry]. They are compatible with popular
+containerised Ceph deployment tools such as:
 
-We support 2 backends: Cephadm and Rook. The features each support differ, and this compatibility matrix aims to document what is achievable for both.
+* [Cephadm][ubuntu-discourse-cephadm]
+* [Rook][ubuntu-discourse-ceph-rook]
 
-> **_NOTE:_**
-A green light means that a particular feature is supported, and a red light means that it isn't. A yellow light means that a feature is _technically_ supported, but needs operator intervention.
+## Supported features
 
-| Feature | Cephadm | Rook | Feature | Cephadm | Rook |
-| ------- | ------- | ---- | ------- | ------- | ---- |
-| Upgrade | &#x1F7E2; | &#x1F7E1; | Dashboard | &#x1F7E2; | &#x1F7E2; |
-| Status | &#x1F7E2; | &#x1F7E2; | Loki | &#x1F7E2; | &#x1F534; |
-| ps | &#x1F7E2; | &#x1F7E2; | Prometheus | &#x1F7E2; | &#x1F534; |
-| ls | &#x1F7E2; | &#x1F7E2; | Alert manager | &#x1F7E2; | &#x1F534; |
-| RadosGW | &#x1F7E2; | &#x1F7E1; | Node exporter | &#x1F7E2; | &#x1F534; |
-| Hosts | &#x1F7E2; | &#x1F7E2; | OSD ops | &#x1F7E2; | &#x1F7E2; |
-| Hosts (maintenance) | &#x1F7E2; | &#x1F534; | ISCSI | &#x1F7E2; | &#x1F534; |
-| Device ops | &#x1F7E2; | &#x1F7E2; | RBD Mirror | &#x1F7E2; | &#x1F7E2; |
-| Status | &#x1F7E2; | &#x1F7E1; | | | |
+Our ROCKs support two backends: Cephadm and Rook. The features that each
+support are given below.
 
+| Feature | Cephadm | Rook |
+| ------- | ------- | ---- |
+| Status | &#x1F7E2; | &#x1F7E2; |
+| ps | &#x1F7E2; | &#x1F7E2; |
+| ls | &#x1F7E2; | &#x1F7E2; |
+| Hosts | &#x1F7E2; | &#x1F7E2; |
+| Device ops | &#x1F7E2; | &#x1F7E2; |
+| Dashboard | &#x1F7E2; | &#x1F7E2; |
+| OSD ops | &#x1F7E2; | &#x1F7E2; |
+| RBD Mirror | &#x1F7E2; | &#x1F7E2; |
+| RadosGW | &#x1F7E2; | &#x1F7E1; |
+| Status | &#x1F7E2; | &#x1F7E1; |
+| Upgrade | &#x1F7E2; | &#x1F7E1; |
+| Hosts (maintenance) | &#x1F7E2; | &#x1F534; |
+| ISCSI | &#x1F7E2; | &#x1F534; |
+| Loki | &#x1F7E2; | &#x1F534; |
+| Prometheus | &#x1F7E2; | &#x1F534; |
+| Alert manager | &#x1F7E2; | &#x1F534; |
+| Node exporter | &#x1F7E2; | &#x1F534; |
+
+**Legend**
+
+&#x1F7E2; : fully supported  
+&#x1F7E1; : _technically_ supported - requires operator intervention  
+&#x1F534; : not supported
+
+<!-- LINKS -->
+
+[wikipedia-oci]: https://en.wikipedia.org/wiki/Open_Container_Initiative
+[definition-rocks]: https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/#rocks-explanation
+[github-ceph-containers-registry]: https://github.com/canonical/ceph-containers/pkgs/container/ceph
+[ubuntu-discourse-cephadm]: https://discourse.ubuntu.com/t/using-cephadm-to-deploy-custom-ubuntu-ceph-images-in-a-containerised-manner
+[ubuntu-discourse-ceph-rook]: https://discourse.ubuntu.com/t/deploying-ceph-with-rook

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ support are given below.
 | OSD ops | &#x1F7E2; | &#x1F7E2; |
 | RBD Mirror | &#x1F7E2; | &#x1F7E2; |
 | RadosGW | &#x1F7E2; | &#x1F7E1; |
-| Status | &#x1F7E2; | &#x1F7E1; |
+| Daemon status | &#x1F7E2; | &#x1F7E1; |
 | Upgrade | &#x1F7E2; | &#x1F7E1; |
 | Hosts (maintenance) | &#x1F7E2; | &#x1F534; |
 | ISCSI | &#x1F7E2; | &#x1F534; |


### PR DESCRIPTION
This is a documentation-only review of the `README` and `HACKING` files. 

In the `README` file, in the feature table, the **STATUS** feature is repeated. We should wait for clarification on this aspect before merging.

In the `HACKING` file, things can be improved at a later time by placing links at the bottom of the file (and using a label), as was done in the README file.