### PR TITLE
Fix LXD dependency in release jobs

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -20,11 +20,14 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: 5.20/stable
+
       - name: Install deps and clean legacy rules.
         run: |
-          sudo snap install lxd
-          sudo snap install rockcraft --classic --edge
-          sudo lxd init --auto
+          sudo snap install rockcraft --classic --channel latest/stable
           for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
           sudo systemctl reload snap.lxd.daemon
           sleep 5

--- a/.github/workflows/publish_hotfix.yaml
+++ b/.github/workflows/publish_hotfix.yaml
@@ -31,11 +31,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: 5.20/stable
+
       - name: Install deps and clean legacy rules.
         run: |
-          sudo snap install lxd
-          sudo snap install rockcraft --classic --edge
-          sudo lxd init --auto
+          sudo snap install rockcraft --classic --channel latest/stable
           for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
           sudo systemctl reload snap.lxd.daemon
           sleep 5

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -19,11 +19,14 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: 5.20/stable
+
       - name: Install deps and clean legacy rules.
         run: |
-          sudo snap install lxd
-          sudo snap install rockcraft --classic --edge
-          sudo lxd init --auto
+          sudo snap install rockcraft --classic --channel latest/stable
           for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
           sudo systemctl reload snap.lxd.daemon
           sleep 5

--- a/.github/workflows/registry_housekeeping.yaml
+++ b/.github/workflows/registry_housekeeping.yaml
@@ -14,12 +14,13 @@ jobs:
         uses: snok/container-retention-policy@v2
         with:
           image-names: hotfix-*
-          cut-off: one day ago UTC
+          cut-off: one month ago UTC
           timestamp-to-use: updated_at
           untagged-only: true
           account-type: org
           org-name: canonical
           token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
 
       - name: Delete all tagged Hotfixes older than 6 months.
         uses: snok/container-retention-policy@v2
@@ -30,3 +31,4 @@ jobs:
           account-type: org
           org-name: canonical
           token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token


### PR DESCRIPTION
- pin LXD to 5.20
- pin Charmcraft to latest/stable
- add token-type in cleanup jobs