### PR TITLE
Replaced Docker Import with Skopeo copy

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -65,7 +65,7 @@ jobs:
             for tag in $TAGS; do
               echo "$tag"
               docker image ls -a
-              docker import ${{ steps.rockcraft.outputs.rock }} $tag
+              rockcraft.skopeo --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:$tag
             done
             docker image ls -a
             sleep 10

--- a/.github/workflows/publish_hotfix.yaml
+++ b/.github/workflows/publish_hotfix.yaml
@@ -76,7 +76,7 @@ jobs:
             for tag in $TAGS; do
               echo "$tag"
               docker image ls -a
-              docker import ${{ steps.rockcraft.outputs.rock }} $tag
+              rockcraft.skopeo --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:$tag
             done
             docker image ls -a
             sleep 10


### PR DESCRIPTION
Docker `import` command works for archives but has an expectation of flat filesystem tar. A rock when imported with `docker import` corrupts the image but doesn't throw any errors.