### PR TITLE
add prometheus alerts file for built-in alerting module

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -41,6 +41,7 @@ parts:
             - ceph-mgr-diskprediction-local
             - ceph-mgr-k8sevents
             - ceph-mgr-rook
+            - ceph-prometheus-alerts
             - ceph-grafana-dashboards
             - radosgw
             - nfs-ganesha


### PR DESCRIPTION
Fixes #86.

This fix will need to be backported to Quincy. Please let me know if anything else is needed to have this included in the Quincy images.