### PR TITLE
Revert to Noble base for Squid 19.2.3

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -7,6 +7,9 @@ license: Apache-2.0
 platforms:
     amd64:
 
+annotations:
+    ceph: "True"
+
 services:
     ceph-container:
         override: replace

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,17 +1,11 @@
 name: ceph
-base: ubuntu@22.04
+base: ubuntu@24.04
 version: '0.1' # replaced by CI when building to publish.
 summary: Ubuntu based Ceph container image
-description: Rock for Containerised Ceph based on Ubuntu Ceph distribution. 
+description: Rock for Containerised Ceph based on Ubuntu Ceph distribution.
 license: Apache-2.0
 platforms:
     amd64:
-
-# Building squid from Jammy, as py03 is broken on py312 (noble). 
-package-repositories:
-  - type: apt
-    cloud: caracal 
-    priority: always
 
 services:
     ceph-container:
@@ -64,7 +58,7 @@ parts:
             - attr # utilities for manipulating filesystem extended attributes
             - targetcli-fb
             - uuid-runtime
-            - python-setuptools
+            - python3-setuptools
             - udev
             - dmsetup
             - ceph-volume

--- a/scripts/deploy-helper.sh
+++ b/scripts/deploy-helper.sh
@@ -22,7 +22,7 @@ function install_custom_runner_dependencies() {
   sudo apt-get -y update
   # for recent skopeo client
   sudo snap install rockcraft --classic
-  sudo pip install flake8 pep8-naming pylxd pyyaml argparse
+  pip install --user flake8 pep8-naming pylxd pyyaml argparse
   sudo snap install docker
   sleep 10
 }
@@ -44,7 +44,7 @@ function deploy_cluster_with_custom_image() {
   local yaml=${1:?missing}
   local img=${2:?missing}
   sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\//}|g" $yaml
-  sed -i "s|image: quay.io/ceph/ceph:v17.*|image: $img|g" $yaml
+  sed -i "s|image: quay.io/ceph/ceph:v.*|image: $img|g" $yaml
   kubectl create -f $yaml
 }
 
@@ -66,7 +66,7 @@ function deploy_cluster() {
   kubectl create -f filesystem-mirror.yaml
   kubectl create -f nfs-test.yaml
   kubectl create -f subvolumegroup.yaml
-  deploy_operator_with_custom_image toolbox.yaml $img $operator_img
+  deploy_operator_with_custom_image toolbox.yaml $operator_img
 }
 
 

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -59,7 +59,7 @@ function install_apt() {
 }
 
 function bootstrap() {
-    local image="${1:missing}"
+    local image="${1:?missing}"
     local ip="${2:?missing}"
     sudo cephadm --image $image bootstrap --mon-ip $ip --single-host-defaults --skip-dashboard --skip-monitoring-stack
     df -H
@@ -117,7 +117,7 @@ function wait_num_objs() {
   
   for i in {1..15}; do
     num_objs=$( get_num_objs $what )
-    if [ $num_objs == $expect]; then
+    if [ "$num_objs" == "$expect" ]; then
       break
     else
       echo "$what $expect, got $num_objs..."
@@ -125,7 +125,7 @@ function wait_num_objs() {
     fi
   done
 
-  if [ $num_objs != $expect]; then
+  if [ "$num_objs" != "$expect" ]; then
     echo "Timedout waiting for $what to reach $expect count"
     exit -1 
   fi
@@ -136,7 +136,7 @@ function test_num_objs() {
     local expect=${2:?missing}
     
     num_objs=$( get_num_objs $what )
-    if [ $num_objs == $expect ]; then
+    if [ "$num_objs" == "$expect" ]; then
         echo "[OK] test_num_objs $what $expect"
     else
         echo "[FAIL] test_num_objs $what $expect, got $num_objs"


### PR DESCRIPTION
## Summary
- Reverts base from Jammy (22.04) to Noble (24.04) now that the pyo3 issue in ceph-mgr is fixed in Squid 19.2.3
- Removes UCA `caracal` package-repositories — Noble ships Squid natively in `noble-updates/main`
- Fixes `python-setuptools` → `python3-setuptools` for Noble compatibility
- Fixes bugs in test scripts (`deploy-helper.sh`, `cephadm_helper.sh`)

## Test plan
- [x] `rockcraft pack` builds successfully with Noble base (ceph-common 19.2.3-0ubuntu0.24.04.2)
- [ ] Cephadm deployment test passes
- [ ] Rook deployment test passes
- [ ] CI canary tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)