### PR TITLE
ci: Remove unused pip dependencies

### DIFF
--- a/scripts/deploy-helper.sh
+++ b/scripts/deploy-helper.sh
@@ -22,7 +22,6 @@ function install_custom_runner_dependencies() {
   sudo apt-get -y update
   # for recent skopeo client
   sudo snap install rockcraft --classic
-  sudo pip install flake8 pep8-naming pylxd pyyaml argparse
   sudo snap install docker
   sleep 10
 }


### PR DESCRIPTION
Unused pip deps break Cephadm test - eg:

```
  Attempting uninstall: cryptography
    Found existing installation: cryptography 41.0.7
ERROR: Cannot uninstall cryptography 41.0.7, RECORD file not found. Hint: The package was installed by debian.
```