### PR TITLE
Add missing Squid image packages

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -29,6 +29,8 @@ jobs:
       - name: Prepare Rock
         uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
+      - name: Add cephadm image label
+        run: scripts/add-oci-label ${{ steps.rockcraft.outputs.rock }} ceph True
       - uses: actions/upload-artifact@v4
         with:
           name: rock

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -144,7 +144,8 @@ jobs:
               loop_devices+=("${loop_device##*/}")
             done
             printf 'ALLOW_LOOP_DEVICES=true\n' >> "$GITHUB_ENV"
-            printf 'BLOCK=/dev/(%s)\n' "$(IFS='|'; echo "${loop_devices[*]}")" >> "$GITHUB_ENV"
+            printf -v rook_devices '%s,' "${loop_devices[@]/#/\/dev\/}"
+            printf 'ROOK_CEPH_DEVICES=%s\n' "${rook_devices%,}" >> "$GITHUB_ENV"
             sudo lsblk
           fi
 

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -155,14 +155,17 @@ jobs:
 
       - name: Load image and load to registry
         run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
           ls
           rock_file=$(ls *.rock | head -1)
           docker run -d -p 5000:5000 --restart=always --name registry registry:2
-          rockcraft.skopeo --insecure-policy copy oci-archive:$rock_file docker-daemon:canonical/ceph:latest
-          docker image ls -a
-          docker image tag canonical/ceph:latest localhost:5000/canonical/ceph:latest
           sleep 10
-          docker push localhost:5000/canonical/ceph
+          skopeo --insecure-policy copy \
+            --dest-tls-verify=false \
+            oci-archive:$rock_file \
+            docker://localhost:5000/canonical/ceph:latest
+          skopeo inspect --tls-verify=false docker://localhost:5000/canonical/ceph:latest | jq -e '.Labels.ceph == "True"'
           echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
 
       - name: deploy cluster

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -133,8 +133,20 @@ jobs:
       - name: use local disk and create partitions for osds
         run: |
           cd rook
-          ./tests/scripts/github-action-helper.sh use_local_disk
-          ./tests/scripts/github-action-helper.sh create_partitions_for_osds
+          if sudo lsblk --paths | awk '/14G/ || /64G/ { found=1 } END { exit !found }'; then
+            ./tests/scripts/github-action-helper.sh use_local_disk
+            ./tests/scripts/github-action-helper.sh create_partitions_for_osds
+          else
+            loop_devices=()
+            for i in 1 2; do
+              sudo dd if=/dev/zero of="$HOME/rook-osd-${i}.img" bs=1M seek=6144 count=0
+              loop_device="$(sudo losetup --find --show "$HOME/rook-osd-${i}.img")"
+              loop_devices+=("${loop_device##*/}")
+            done
+            printf 'ALLOW_LOOP_DEVICES=true\n' >> "$GITHUB_ENV"
+            printf 'BLOCK=/dev/(%s)\n' "$(IFS='|'; echo "${loop_devices[*]}")" >> "$GITHUB_ENV"
+            sudo lsblk
+          fi
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -169,7 +169,7 @@ jobs:
           echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
 
       - name: deploy cluster
-        run: ./scripts/deploy-helper.sh deploy_cluster
+        run: ./scripts/deploy-helper.sh deploy_cluster rook/ceph:v1.12.0 localhost:5000/canonical/ceph:latest
 
       - name: wait for prepare pod
         run: cd rook ; tests/scripts/github-action-helper.sh wait_for_prepare_pod ; sleep 100

--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -61,6 +61,8 @@ jobs:
       - name: Prepare Rock
         uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
+      - name: Add cephadm image label
+        run: scripts/add-oci-label ${{ steps.rockcraft.outputs.rock }} ceph True
 
       - name: Load to Docker daemon
         run: |
@@ -75,4 +77,3 @@ jobs:
             docker push ghcr.io/canonical/ceph --all-tags
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
-

--- a/.github/workflows/publish_hotfix.yaml
+++ b/.github/workflows/publish_hotfix.yaml
@@ -71,6 +71,8 @@ jobs:
       - name: Prepare Rock
         uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
+      - name: Add cephadm image label
+        run: scripts/add-oci-label ${{ steps.rockcraft.outputs.rock }} ceph True
 
       - name: Load to Docker daemon
         run: |

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -62,6 +62,8 @@ jobs:
       - name: Prepare Rock
         uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
+      - name: Add cephadm image label
+        run: scripts/add-oci-label ${{ steps.rockcraft.outputs.rock }} ceph True
 
       - name: Load to Docker daemon
         run: |

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -43,18 +43,23 @@ parts:
             - ceph-mgr-rook
             - ceph-prometheus-alerts
             - ceph-grafana-dashboards
+            - ceph-immutable-object-cache
             - radosgw
             - nfs-ganesha
             - nfs-ganesha-ceph
             - nfs-ganesha-rados-grace
+            - nfs-ganesha-rgw
             - cephfs-mirror
             - ceph-iscsi
             - ceph-fuse
+            - python3-rgw
             - rbd-nbd
             - rbd-mirror
             # Utilities
             - gnupg 
             - ca-certificates
+            - curl
+            - jq
             - kmod
             - lvm2
             - gdisk
@@ -89,5 +94,4 @@ parts:
             logrotate.d/* : ${CRAFT_PART_INSTALL}/etc/logrotate.d/
             # Ceph defaults
             ceph.defaults : ${CRAFT_PART_INSTALL}/opt/ceph-container/etc/
-
 

--- a/scripts/add-oci-label
+++ b/scripts/add-oci-label
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Add an OCI config label to an OCI archive."""
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _read_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def _write_blob(blobs_dir: Path, payload: dict) -> tuple[str, int]:
+    data = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    digest = _sha256(data)
+    (blobs_dir / digest).write_bytes(data)
+    return digest, len(data)
+
+
+def _safe_extract(archive: Path, destination: Path) -> None:
+    with tarfile.open(archive) as tar:
+        for member in tar.getmembers():
+            member_path = destination / member.name
+            if member_path.resolve().is_relative_to(destination.resolve()):
+                continue
+            raise RuntimeError(f"Refusing to extract unsafe path: {member.name}")
+        tar.extractall(destination)
+
+
+def _repack(source: Path, destination: Path) -> None:
+    with tarfile.open(destination, "w") as tar:
+        for name in ("oci-layout", "index.json", "blobs"):
+            tar.add(source / name, arcname=name)
+
+
+def add_label(archive: Path, label: str, value: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="oci-label-") as tmp:
+        workdir = Path(tmp)
+        _safe_extract(archive, workdir)
+
+        index_path = workdir / "index.json"
+        blobs_dir = workdir / "blobs" / "sha256"
+        index = _read_json(index_path)
+
+        for descriptor in index["manifests"]:
+            manifest_digest = descriptor["digest"].removeprefix("sha256:")
+            manifest_path = blobs_dir / manifest_digest
+            manifest = _read_json(manifest_path)
+
+            config_digest = manifest["config"]["digest"].removeprefix("sha256:")
+            config = _read_json(blobs_dir / config_digest)
+            config.setdefault("config", {}).setdefault("Labels", {})[label] = value
+
+            new_config_digest, new_config_size = _write_blob(blobs_dir, config)
+            manifest["config"]["digest"] = f"sha256:{new_config_digest}"
+            manifest["config"]["size"] = new_config_size
+
+            new_manifest_digest, new_manifest_size = _write_blob(blobs_dir, manifest)
+            descriptor["digest"] = f"sha256:{new_manifest_digest}"
+            descriptor["size"] = new_manifest_size
+
+        with index_path.open("w", encoding="utf-8") as file:
+            json.dump(index, file, separators=(",", ":"), sort_keys=True)
+
+        tmp_archive = archive.with_suffix(f"{archive.suffix}.tmp")
+        _repack(workdir, tmp_archive)
+        shutil.move(tmp_archive, archive)
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print("Usage: add-oci-label <oci-archive> <label> <value>", file=sys.stderr)
+        return 2
+
+    archive = Path(sys.argv[1])
+    if not archive.is_file():
+        print(f"OCI archive not found: {archive}", file=sys.stderr)
+        return 1
+
+    add_label(archive, sys.argv[2], sys.argv[3])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy-helper.sh
+++ b/scripts/deploy-helper.sh
@@ -30,8 +30,13 @@ function install_custom_runner_dependencies() {
 function deploy_operator_with_custom_image() {
   local yaml=${1:?missing}
   local img=${2:?missing}
+  local escaped_img="${img//\\/\\\\}"
+  escaped_img="${escaped_img//&/\\&}"
+  escaped_img="${escaped_img//|/\\|}"
+
   sed -i 's/.*ROOK_CSI_ENABLE_NFS:.*/  ROOK_CSI_ENABLE_NFS: \"true\"/g' $yaml
-  sed -i "s|image: rook/ceph:.*|image: $img|g" $yaml
+  sed -i "s|image: rook/ceph:.*|image: $escaped_img|g" $yaml
+  sed -i "s|image: .*ceph/ceph:v[0-9].*|image: $escaped_img|g" $yaml
   if [[ "$ALLOW_LOOP_DEVICES" = "true" ]]; then
     sed -i "s|ROOK_CEPH_ALLOW_LOOP_DEVICES: \"false\"|ROOK_CEPH_ALLOW_LOOP_DEVICES: \"true\"|g" $yaml
   fi
@@ -42,12 +47,33 @@ function deploy_operator_with_custom_image() {
 function deploy_cluster_with_custom_image() {
   local yaml=${1:?missing}
   local img=${2:?missing}
-  local device_filter="${BLOCK/\/dev\//}"
-  device_filter="${device_filter//\\/\\\\}"
-  device_filter="${device_filter//&/\\&}"
-  device_filter="${device_filter//|/\\|}"
-  sed -i "s|#deviceFilter:|deviceFilter: ${device_filter}|g" $yaml
-  sed -i "s|image: quay.io/ceph/ceph:v17.*|image: $img|g" $yaml
+  local escaped_img="${img//\\/\\\\}"
+  escaped_img="${escaped_img//&/\\&}"
+  escaped_img="${escaped_img//|/\\|}"
+
+  if [[ -n "${ROOK_CEPH_DEVICES:-}" ]]; then
+    awk -v devices="$ROOK_CEPH_DEVICES" '
+      /#deviceFilter:/ {
+        indent = substr($0, 1, index($0, "#") - 1)
+        print indent "devices:"
+        count = split(devices, device, ",")
+        for (i = 1; i <= count; i++) {
+          print indent "  - name: \"" device[i] "\""
+        }
+        next
+      }
+      { print }
+    ' "$yaml" > "$yaml.tmp"
+    mv "$yaml.tmp" "$yaml"
+  else
+    local device_filter="${BLOCK/\/dev\//}"
+    device_filter="${device_filter//\\/\\\\}"
+    device_filter="${device_filter//&/\\&}"
+    device_filter="${device_filter//|/\\|}"
+    sed -i "s|#deviceFilter:|deviceFilter: ${device_filter}|g" $yaml
+  fi
+
+  sed -i "s|image: .*ceph/ceph:v[0-9].*|image: $escaped_img|g" $yaml
   kubectl create -f $yaml
 }
 

--- a/scripts/deploy-helper.sh
+++ b/scripts/deploy-helper.sh
@@ -50,8 +50,13 @@ function deploy_cluster_with_custom_image() {
 function deploy_cluster() {
   local operator_default="rook/ceph:v1.12.0"
   local operator_img=${1:-"$operator_default"}
-  local cluster_default="$( cat custom-image-spec )"
-  local cluster_img=${2:-"$cluster_default"}
+  local cluster_img
+
+  if [[ -n "${2:-}" ]]; then
+    cluster_img="$2"
+  else
+    cluster_img="$( cat custom-image-spec )"
+  fi
 
   cd rook/deploy/examples
   deploy_operator_with_custom_image operator.yaml $operator_img
@@ -65,7 +70,7 @@ function deploy_cluster() {
   kubectl create -f filesystem-mirror.yaml
   kubectl create -f nfs-test.yaml
   kubectl create -f subvolumegroup.yaml
-  deploy_operator_with_custom_image toolbox.yaml $img $operator_img
+  deploy_operator_with_custom_image toolbox.yaml $cluster_img
 }
 
 

--- a/scripts/deploy-helper.sh
+++ b/scripts/deploy-helper.sh
@@ -42,7 +42,11 @@ function deploy_operator_with_custom_image() {
 function deploy_cluster_with_custom_image() {
   local yaml=${1:?missing}
   local img=${2:?missing}
-  sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\//}|g" $yaml
+  local device_filter="${BLOCK/\/dev\//}"
+  device_filter="${device_filter//\\/\\\\}"
+  device_filter="${device_filter//&/\\&}"
+  device_filter="${device_filter//|/\\|}"
+  sed -i "s|#deviceFilter:|deviceFilter: ${device_filter}|g" $yaml
   sed -i "s|image: quay.io/ceph/ceph:v17.*|image: $img|g" $yaml
   kubectl create -f $yaml
 }

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -34,11 +34,12 @@ function configure_insecure_registry() {
   ls
   rock_file=$(ls *.rock | head -1)
   docker run -d -p 5000:5000 --restart=always --name registry registry:2
-  rockcraft.skopeo --insecure-policy copy oci-archive:$rock_file docker-daemon:canonical/ceph:latest
-  docker image ls -a
-  docker image tag canonical/ceph:latest localhost:5000/canonical/ceph:latest
   sleep 10
-  docker push localhost:5000/canonical/ceph
+  rockcraft.skopeo --insecure-policy copy \
+    --dest-tls-verify=false \
+    oci-archive:$rock_file \
+    docker://localhost:5000/canonical/ceph:latest
+  rockcraft.skopeo inspect --tls-verify=false docker://localhost:5000/canonical/ceph:latest | jq -e '.Labels.ceph == "True"'
   sudo touch /etc/docker/daemon.json
   # dont need insecure registry since it's localhost.
   # echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/docker/daemon.json


### PR DESCRIPTION
## Summary
- Keep Squid on ubuntu@22.04 plus the Caracal cloud archive and add only the missing runtime packages available through apt: ceph-immutable-object-cache, nfs-ganesha-rgw, python3-rgw, curl, and jq.
- Add a stdlib OCI archive relabel step so packed rocks carry ceph=True for cephadm image inference.
- Update CI image loading to copy OCI archives directly into local registries instead of loading through the Docker daemon, preserving registry digest metadata.
- Make Rook CI more tolerant of hosted runners by falling back to explicit loop devices, installing apt skopeo, and passing the test image explicitly.

## Intentionally not included
- No Noble base change for Squid.
- No pip install or --break-system-packages usage.
- No gap document in the repo.

## Validation
- Local: rebuilt the Jammy/Caracal Squid rock with rockcraft pack.
- Local: verified scripts/add-oci-label on a copied rock with rockcraft.skopeo inspect showing .Labels.ceph == "True".
- Local: validated cephadm bootstrap and OSD deployment on a Noble LXD VM using the local registry image.
- CI: all PR checks pass: cla-check, Lint, build-rock, CephadmTest (3.10), and RookTest.