### PR TITLE
Tolerate busy iptables chains in workflows

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -87,7 +87,15 @@ jobs:
 
       - name: clean iptables legacy
         run: |
-          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
+          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
+            sudo $ipt --flush || true
+            sudo $ipt --flush -t nat || true
+            sudo $ipt --delete-chain || true
+            sudo $ipt --delete-chain -t nat || true
+            sudo $ipt -P FORWARD ACCEPT || true
+            sudo $ipt -P INPUT ACCEPT || true
+            sudo $ipt -P OUTPUT ACCEPT || true
+          done
           sudo systemctl reload snap.lxd.daemon
           sleep 5
 

--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -27,7 +27,15 @@ jobs:
         run: |
           sudo snap install docker
           sudo snap install rockcraft --classic --channel latest/stable
-          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
+          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
+            sudo $ipt --flush || true
+            sudo $ipt --flush -t nat || true
+            sudo $ipt --delete-chain || true
+            sudo $ipt --delete-chain -t nat || true
+            sudo $ipt -P FORWARD ACCEPT || true
+            sudo $ipt -P INPUT ACCEPT || true
+            sudo $ipt -P OUTPUT ACCEPT || true
+          done
           sudo systemctl reload snap.lxd.daemon
           sleep 5
 

--- a/.github/workflows/publish_hotfix.yaml
+++ b/.github/workflows/publish_hotfix.yaml
@@ -38,7 +38,15 @@ jobs:
         run: |
           sudo snap install docker
           sudo snap install rockcraft --classic --channel latest/stable
-          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
+          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
+            sudo $ipt --flush || true
+            sudo $ipt --flush -t nat || true
+            sudo $ipt --delete-chain || true
+            sudo $ipt --delete-chain -t nat || true
+            sudo $ipt -P FORWARD ACCEPT || true
+            sudo $ipt -P INPUT ACCEPT || true
+            sudo $ipt -P OUTPUT ACCEPT || true
+          done
           sudo systemctl reload snap.lxd.daemon
           sleep 5
 

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -26,7 +26,15 @@ jobs:
         run: |
           sudo snap install docker
           sudo snap install rockcraft --classic --channel latest/stable
-          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
+          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
+            sudo $ipt --flush || true
+            sudo $ipt --flush -t nat || true
+            sudo $ipt --delete-chain || true
+            sudo $ipt --delete-chain -t nat || true
+            sudo $ipt -P FORWARD ACCEPT || true
+            sudo $ipt -P INPUT ACCEPT || true
+            sudo $ipt -P OUTPUT ACCEPT || true
+          done
           sudo systemctl reload snap.lxd.daemon
           sleep 5
 


### PR DESCRIPTION
## Summary
- make iptables cleanup tolerant of busy or missing chains in publish workflows
- apply the same cleanup guard to the cephadm test workflow

## Reason
The post-merge edge release failed before packing because ip6tables could not delete the Docker chain while it was busy. These cleanup commands are best-effort runner preparation and should not fail the release job.

## Validation
- python3 YAML parse for affected workflows
- git diff --check