### PR TITLE
Prepare main for Ceph Tentacle

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -179,6 +179,12 @@ jobs:
           skopeo inspect --tls-verify=false docker://localhost:5000/canonical/ceph:latest | jq -e '.Labels.ceph == "True"'
           echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
 
+      # Rook >=1.19 splits CSI into a standalone ceph-csi-operator. The
+      # rook-ceph-operator's reconcile blocks on csi.ceph.io/v1 CRDs
+      # (OperatorConfig, CephConnection); install them up front.
+      - name: install ceph-csi-operator CRDs
+        run: kubectl create -f rook/deploy/examples/csi-operator.yaml
+
       - name: deploy cluster
         run: ./scripts/deploy-helper.sh deploy_cluster rook/ceph:v1.19.5 localhost:5000/canonical/ceph:latest
 

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -26,6 +26,8 @@ jobs:
         uses: canonical/setup-lxd@v0.1.1
         with:
           channel: 5.21/stable
+      - name: Install Rockcraft
+        run: sudo snap install rockcraft --classic --channel latest/edge
       - name: Prepare Rock
         uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
@@ -178,7 +180,7 @@ jobs:
           echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
 
       - name: deploy cluster
-        run: ./scripts/deploy-helper.sh deploy_cluster rook/ceph:v1.12.0 localhost:5000/canonical/ceph:latest
+        run: ./scripts/deploy-helper.sh deploy_cluster rook/ceph:v1.19.5 localhost:5000/canonical/ceph:latest
 
       - name: wait for prepare pod
         run: cd rook ; tests/scripts/github-action-helper.sh wait_for_prepare_pod ; sleep 100

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -216,7 +216,11 @@ jobs:
           cd rook
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           kubectl -n rook-ceph exec $toolbox -- mkdir -p /etc/ceph/test-data
-          kubectl -n rook-ceph cp tests/ceph-status-out $toolbox:/etc/ceph/test-data/
+          # Rook v1.19 moved test fixtures: tests/ceph-status-out ->
+          # tests/external-cluster/ceph-status-out and added a required
+          # external-config.ini sibling.
+          kubectl -n rook-ceph cp tests/external-cluster/ceph-status-out $toolbox:/etc/ceph/test-data/
+          kubectl -n rook-ceph cp tests/external-cluster/external-config.ini $toolbox:/etc/ceph/
           kubectl -n rook-ceph cp deploy/examples/create-external-cluster-resources.py $toolbox:/etc/ceph
           kubectl -n rook-ceph cp deploy/examples/create-external-cluster-resources-tests.py $toolbox:/etc/ceph
           timeout 10 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool; do echo 'waiting for script to succeed' && sleep 1; done"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -347,17 +347,25 @@ jobs:
           # print upgraded client auth
           kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
 
+      # The CephObjectStore is named `my-store`, so its RGW realm,
+      # zonegroup and zone are all `my-store`. Without explicit
+      # --rgw-realm-name/-zonegroup-name/-zone-name, create-external-
+      # cluster-resources.py creates `rgw-admin-ops-user` in the empty
+      # default zone, and the admin-ops API call against the `my-store`
+      # endpoint returns 403 (unknown user). Pass the store name to all
+      # validations against the in-cluster RGW.
       - name: validate-rgw-endpoint
         run: |
           cd rook
-          rgw_endpoint=$(kubectl get service -n rook-ceph |  awk '/rgw/ {print $3":80"}')
+          rgw_endpoint=$(kubectl get service -n rook-ceph -l rgw=my-store | awk '/rgw/ {print $3":80"}')
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+          rgw_args="--rgw-realm-name my-store --rgw-zonegroup-name my-store --rgw-zone-name my-store"
           # pass the valid rgw-endpoint of same ceph cluster
-          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint $rgw_args 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
           tests/scripts/github-action-helper.sh check_empty_file output.txt
           rm -f output.txt
           # pass the invalid rgw-endpoint of different ceph cluster
-          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint 10.108.96.128:80  2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint 10.108.96.128:80 $rgw_args 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
           if [ -s output.txt ]; then
             echo "script run completed with stderr error after passing the wrong rgw-endpoint: $output"
             rm -f output.txt
@@ -367,11 +375,11 @@ jobs:
             exit 1
           fi
           # pass the valid rgw-endpoint of same ceph cluster with --rgw-tls-cert-path
-          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-tls-cert-path my-cert 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint $rgw_args --rgw-tls-cert-path my-cert 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
           tests/scripts/github-action-helper.sh check_empty_file output.txt
           rm -f output.txt
           # pass the valid rgw-endpoint of same ceph cluster with --rgw-skip-tls
-          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-skip-tls true 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint $rgw_args --rgw-skip-tls true 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
           tests/scripts/github-action-helper.sh check_empty_file output.txt
           rm -f output.txt
 

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -301,9 +301,9 @@ jobs:
         run: |
           cd rook
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          # create `radosNamespace1` rados-namespace for `replicapool` rbd data-pool
-          kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosNamespace1
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosNamespace1
+          # create `radosnamespace1` rados-namespace for `replicapool` rbd data-pool
+          kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosnamespace1
+          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosnamespace1
            # test the rados namespace which not exit for replicapool(false testing)
           if output=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace false-test-namespace); then
             echo "unexpectedly succeeded after passing the wrong rados namespace: $output"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -253,15 +253,15 @@ jobs:
         run: |
           cd rook
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          # update client.csi-rbd-provisioner csi user caps
-          # print client.csi-rbd-provisioner user before update
-          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-provisioner
-          kubectl -n rook-ceph exec $toolbox -- ceph auth caps client.csi-rbd-provisioner mon 'profile rbd, allow command "osd ls"' osd 'profile rbd' mgr 'allow rw'
-          # print client.csi-rbd-provisioner user after update
-          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-provisioner
+          # update client.csi-rbd-provisioner.1 csi user caps
+          # print client.csi-rbd-provisioner.1 user before update
+          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-provisioner.1
+          kubectl -n rook-ceph exec $toolbox -- ceph auth caps client.csi-rbd-provisioner.1 mon 'profile rbd, allow command "osd ls"' osd 'profile rbd' mgr 'allow rw'
+          # print client.csi-rbd-provisioner.1 user after update
+          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-provisioner.1
           kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool
-          # print client.csi-rbd-provisioner user after running script
-          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-provisioner
+          # print client.csi-rbd-provisioner.1 user after running script
+          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-provisioner.1
 
       - name: run external script create-external-cluster-resources.py unit tests
         run: |

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -191,8 +191,17 @@ jobs:
       - name: wait for prepare pod
         run: cd rook ; tests/scripts/github-action-helper.sh wait_for_prepare_pod ; sleep 100
 
+      # Rook v1.19 changed validate_cluster.sh's rgw probe to select pods
+      # by `rgw=$OBJECT_STORE_NAME` and hardcodes `store-a` when called
+      # with daemon=all. We deploy object-test.yaml whose CephObjectStore
+      # is named `my-store`, so the default selector misses and the rgw
+      # wait times out. Validate non-rgw daemons via the helper, then
+      # wait on the rgw deployment directly using its app= label.
       - name: wait for ceph to be ready
-        run: cd rook ; tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready all 2
+        run: |
+          cd rook
+          tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready 'osd,mds,rbd_mirror,fs_mirror,nfs' 2
+          kubectl -n rook-ceph rollout status deployment/rook-ceph-rgw-my-store-a --timeout=360s
 
       - name: wait for ceph mgr to be ready
         run: |

--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -9,15 +9,15 @@ runs:
   using: "composite"
   steps:
     - name: setup golang
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: "1.24"
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.7.2
+      uses: manusa/actions-setup-minikube@v2.16.1
       with:
-        minikube version: "v1.28.0"
-        kubernetes version: "v1.25.0"
+        minikube version: "v1.38.1"
+        kubernetes version: "v1.35.0"
         start args: --memory 6g --cpus=2 --addons ingress
         github token: ${{ inputs.github-token }}
 
@@ -25,7 +25,7 @@ runs:
       uses: robinraju/release-downloader@v1.6
       with: 
         repository: "rook/rook"
-        tag: "v1.12.8"
+        tag: "v1.19.5"
         tarBall: true
         
         

--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install deps and clean legacy rules.
         run: |
           sudo snap install docker
-          sudo snap install rockcraft --classic --channel latest/stable
+          sudo snap install rockcraft --classic --channel latest/edge
           for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
             sudo $ipt --flush || true
             sudo $ipt --flush -t nat || true
@@ -64,6 +64,7 @@ jobs:
             type=raw,value=quincy-edge,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '17') }}
             type=raw,value=reef-edge,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '18') }}
             type=raw,value=squid-edge,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '19') }}
+            type=raw,value=tentacle-edge,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '20') }}
             type=raw,value=dev-edge,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Prepare Rock

--- a/.github/workflows/publish_hotfix.yaml
+++ b/.github/workflows/publish_hotfix.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install deps and clean legacy rules.
         run: |
           sudo snap install docker
-          sudo snap install rockcraft --classic --channel latest/stable
+          sudo snap install rockcraft --classic --channel latest/edge
           for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
             sudo $ipt --flush || true
             sudo $ipt --flush -t nat || true

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install deps and clean legacy rules.
         run: |
           sudo snap install docker
-          sudo snap install rockcraft --classic --channel latest/stable
+          sudo snap install rockcraft --classic --channel latest/edge
           for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
             sudo $ipt --flush || true
             sudo $ipt --flush -t nat || true
@@ -66,6 +66,7 @@ jobs:
             type=raw,value=quincy,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '17') }}
             type=raw,value=reef,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '18') }}
             type=raw,value=squid,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '19') }}
+            type=raw,value=tentacle,enable=${{ startsWith(steps.versioning.outputs.ceph_version, '20') }}
 
       - name: Prepare Rock
         uses: canonical/craft-actions/rockcraft-pack@main

--- a/patches/0001-mgr_util-add-verify_cacrt_content.patch
+++ b/patches/0001-mgr_util-add-verify_cacrt_content.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Utkarsh Bhatt <utkarsh.bhatt@canonical.com>
+Date: Fri, 1 May 2026 00:00:00 +0000
+Subject: [PATCH] mgr/mgr_util: add missing verify_cacrt_content
+
+The ceph-mgr 20.2.0 build in ppa:lmlogiudice/ceph-tentacle-noble
+ships a mgr_util.py without verify_cacrt_content, while the sibling
+ceph-mgr-cephadm 20.2.0 (same PPA, same version) imports it via
+cephadm/cert_mgr.py. Loading the cephadm mgr module therefore fails
+with ImportError on every bootstrap.
+
+Restore the function verbatim from upstream Ceph v20.2.0
+(src/pybind/mgr/mgr_util.py).
+
+Signed-off-by: Utkarsh Bhatt <utkarsh.bhatt@canonical.com>
+---
+ usr/share/ceph/mgr/mgr_util.py | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/usr/share/ceph/mgr/mgr_util.py b/usr/share/ceph/mgr/mgr_util.py
+--- a/usr/share/ceph/mgr/mgr_util.py
++++ b/usr/share/ceph/mgr/mgr_util.py
+@@ -650,6 +650,30 @@
+         raise ServerConfigException(f'Invalid certificate: {err}')
+
+
++def verify_cacrt_content(crt):
++    # type: (str) -> int
++    from OpenSSL import crypto
++    try:
++        crt_buffer = crt.encode("ascii") if isinstance(crt, str) else crt
++        x509 = crypto.load_certificate(crypto.FILETYPE_PEM, crt_buffer)
++        no_after = x509.get_notAfter()
++        if not no_after:
++            raise ServerConfigException("Certificate does not have an expiration date.")
++
++        end_date = datetime.datetime.strptime(no_after.decode('ascii'), '%Y%m%d%H%M%SZ')
++        if x509.has_expired():
++            org, cn = get_cert_issuer_info(crt)
++            msg = f'Certificate issued by "{org}/{cn}" expired on {end_date}'
++            logger.warning(msg)
++            raise ServerConfigException(msg)
++
++        # Certificate still valid, calculate and return days until expiration
++        return (end_date - datetime.datetime.utcnow()).days
++
++    except (ValueError, crypto.Error) as e:
++        raise ServerConfigException(f'Invalid certificate: {e}')
++
++
+ def verify_cacrt(cert_fname):
+     # type: (str) -> None
+     """Basic validation of a ca cert"""
+--
+2.43.0
+

--- a/patches/0002-mgr-prometheus-fix-string-formatting.patch
+++ b/patches/0002-mgr-prometheus-fix-string-formatting.patch
@@ -1,0 +1,47 @@
+From 6966e1bf7ed9bb93d6855282eb127649391e44c2 Mon Sep 17 00:00:00 2001
+From: Utkarsh Bhatt <utkarsh.bhatt@canonical.com>
+Date: Thu, 20 Mar 2026 00:00:00 +0000
+Subject: [PATCH 2/2] mgr/prometheus: Handle empty JSON from orch
+ get-security-config
+
+Fix TypeError in prometheus module caused by incorrect string
+formatting in exception logging. The f-string with a trailing
+newline was being misinterpreted by Python's logging system.
+
+Upstream fix: https://github.com/ceph/ceph/pull/65033
+Tracker: https://tracker.ceph.com/issues/72380
+
+Signed-off-by: Utkarsh Bhatt <utkarsh.bhatt@canonical.com>
+---
+ usr/share/ceph/mgr/prometheus/module.py | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/usr/share/ceph/mgr/prometheus/module.py b/usr/share/ceph/mgr/prometheus/module.py
+index abcdef1..1234567 100644
+--- a/usr/share/ceph/mgr/prometheus/module.py
++++ b/usr/share/ceph/mgr/prometheus/module.py
+@@ -1834,15 +1834,19 @@
+     def configure(self, server_addr: str, server_port: int) -> None:
+         cmd = {'prefix': 'orch get-security-config'}
+         ret, out, _ = self.mon_command(cmd)
++
+         if ret == 0 and out is not None:
+             try:
+                 security_config = json.loads(out)
+                 if security_config.get('security_enabled', False):
+                     self.setup_tls_config(server_addr, server_port)
+                     return
+             except Exception as e:
+-                self.log.exception(f'Failed to setup cephadm based secure monitoring stack: {e}\n',
+-                                   'Falling back to default configuration')
++                self.log.exception(
++                    'Failed to setup cephadm based secure monitoring stack: %s\n'
++                    'Falling back to default configuration',
++                    e
++                )
+
+         # In any error fallback to plain http mode
+         self.setup_default_config(server_addr, server_port)
+--
+2.43.0
+

--- a/patches/0003-add-stub-smb-mgr-module.patch
+++ b/patches/0003-add-stub-smb-mgr-module.patch
@@ -1,0 +1,95 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Utkarsh Bhatt <utkarsh.bhatt@canonical.com>
+Date: Wed, 9 Apr 2026 14:00:00 +0530
+Subject: [PATCH] Add stub smb mgr module for dashboard compatibility
+
+The ceph-mgr-smb package is not available in the Ubuntu distribution.
+The Ceph tentacle dashboard imports from the smb mgr module
+unconditionally (controllers/smb.py), causing the dashboard to fail
+to load without it.
+
+This adds a minimal stub that satisfies the dashboard's imports
+(Intent, Simplified, Cluster, JoinAuth, Share, UsersAndGroups)
+without providing actual SMB functionality. The dashboard's SMB
+status endpoint will report SMB as unavailable.
+
+Signed-off-by: Utkarsh Bhatt <utkarsh.bhatt@canonical.com>
+---
+ usr/share/ceph/mgr/smb/__init__.py  |  1 +
+ usr/share/ceph/mgr/smb/enums.py     | 17 +++++++++++++++++
+ usr/share/ceph/mgr/smb/proto.py     |  5 +++++
+ usr/share/ceph/mgr/smb/resources.py | 20 ++++++++++++++++++++
+ 4 files changed, 43 insertions(+)
+ create mode 100644 usr/share/ceph/mgr/smb/__init__.py
+ create mode 100644 usr/share/ceph/mgr/smb/enums.py
+ create mode 100644 usr/share/ceph/mgr/smb/proto.py
+ create mode 100644 usr/share/ceph/mgr/smb/resources.py
+
+diff --git a/usr/share/ceph/mgr/smb/__init__.py b/usr/share/ceph/mgr/smb/__init__.py
+new file mode 100644
+index 0000000..b357543
+--- /dev/null
++++ b/usr/share/ceph/mgr/smb/__init__.py
+@@ -0,0 +1 @@
++# Stub smb mgr module — ceph-mgr-smb is not available in the distribution.
+diff --git a/usr/share/ceph/mgr/smb/enums.py b/usr/share/ceph/mgr/smb/enums.py
+new file mode 100644
+index 0000000..a1c2e3f
+--- /dev/null
++++ b/usr/share/ceph/mgr/smb/enums.py
+@@ -0,0 +1,17 @@
++"""Stub enums for the smb mgr module."""
++
++import sys
++
++if sys.version_info >= (3, 11):
++    from enum import StrEnum as _StrEnum
++else:
++    import enum
++
++    class _StrEnum(str, enum.Enum):
++        def __str__(self) -> str:
++            return self.value
++
++
++class Intent(_StrEnum):
++    PRESENT = 'present'
++    REMOVED = 'removed'
+diff --git a/usr/share/ceph/mgr/smb/proto.py b/usr/share/ceph/mgr/smb/proto.py
+new file mode 100644
+index 0000000..d3c5a7e
+--- /dev/null
++++ b/usr/share/ceph/mgr/smb/proto.py
+@@ -0,0 +1,5 @@
++"""Stub proto types for the smb mgr module."""
++
++from typing import Any, Dict
++
++Simplified = Dict[str, Any]
+diff --git a/usr/share/ceph/mgr/smb/resources.py b/usr/share/ceph/mgr/smb/resources.py
+new file mode 100644
+index 0000000..f8e1d2c
+--- /dev/null
++++ b/usr/share/ceph/mgr/smb/resources.py
+@@ -0,0 +1,19 @@
++"""Stub resource types for the smb mgr module."""
++
++from typing import Any, Dict
++
++
++class Cluster(Dict[str, Any]):
++    pass
++
++
++class JoinAuth(Dict[str, Any]):
++    pass
++
++
++class Share(Dict[str, Any]):
++    pass
++
++
++class UsersAndGroups(Dict[str, Any]):
++    pass
+-- 
+2.43.0

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,17 +1,13 @@
 name: ceph
-base: ubuntu@22.04
+base: ubuntu@26.04
+# Rockcraft edge currently needs the devel build-base for 26.04 projects.
+build-base: devel
 version: '0.1' # replaced by CI when building to publish.
 summary: Ubuntu based Ceph container image
 description: Rock for Containerised Ceph based on Ubuntu Ceph distribution. 
 license: Apache-2.0
 platforms:
     amd64:
-
-# Building squid from Jammy, as py03 is broken on py312 (noble). 
-package-repositories:
-  - type: apt
-    cloud: caracal 
-    priority: always
 
 services:
     ceph-container:
@@ -69,7 +65,7 @@ parts:
             - attr # utilities for manipulating filesystem extended attributes
             - targetcli-fb
             - uuid-runtime
-            - python-setuptools
+            - python3-setuptools
             - udev
             - dmsetup
             - ceph-volume
@@ -94,4 +90,3 @@ parts:
             logrotate.d/* : ${CRAFT_PART_INSTALL}/etc/logrotate.d/
             # Ceph defaults
             ceph.defaults : ${CRAFT_PART_INSTALL}/opt/ceph-container/etc/
-

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,13 +16,7 @@ platforms:
 package-repositories:
   - type: apt
     ppa: lmlogiudice/ceph-tentacle-noble
-    # Pin the PPA's signing key so craft-archives skips the launchpadlib
-    # +archive lookup. api.launchpad.net intermittently returns HTTP 503
-    # / hangs on that endpoint with no retry, wedging build-rock for
-    # ~19 minutes before failing. Pinning the fingerprint lets the build
-    # proceed when only Launchpad's web frontend is degraded.
-    # Key owner: "Launchpad PPA for Luciano Lo Giudice".
-    key-id: ADB101EC932F9AEA3800EF9E8871F59B071C7CC2
+    priority: always
 
 services:
     ceph-container:
@@ -56,10 +50,6 @@ parts:
             - ceph-grafana-dashboards
             - ceph-immutable-object-cache
             - radosgw
-            - nfs-ganesha
-            - nfs-ganesha-ceph
-            - nfs-ganesha-rados-grace
-            - nfs-ganesha-rgw
             - cephfs-mirror
             - ceph-iscsi
             - ceph-fuse
@@ -94,8 +84,31 @@ parts:
             cd "${CRAFT_OVERLAY}"
             for p in "${CRAFT_PROJECT_DIR}"/patches/*.patch; do
               echo "Applying ${p}"
-              patch -p1 < "${p}"
+              # --forward + dry-run check makes incremental rebuilds safe:
+              # if the patch is already applied (overlay cache survived
+              # from a prior pack), skip it instead of failing.
+              if patch -p1 --forward --dry-run --silent < "${p}" >/dev/null 2>&1; then
+                patch -p1 --forward < "${p}"
+              else
+                echo "Patch ${p} appears already applied; skipping"
+              fi
             done
+
+    nfs-ganesha:
+        plugin: nil
+        after: [ceph]
+        overlay-packages:
+            - nfs-ganesha
+            - nfs-ganesha-ceph
+            - nfs-ganesha-rados-grace
+            - nfs-ganesha-rgw
+        overlay-script: |
+            # Ubuntu's nfs-ganesha package relies on systemd's
+            # RuntimeDirectory=ganesha to create /run/ganesha at service
+            # start. Rook execs ganesha.nfsd directly inside the container
+            # without systemd, so the dir never exists and ganesha.nfsd
+            # FATALs writing its pidfile. Pre-create it here.
+            install -d -m 0755 "${CRAFT_OVERLAY}/run/ganesha"
 
     kubectl:
         plugin: go

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -82,6 +82,13 @@ parts:
             - sharutils
             - lsof
             - python3-onelogin-saml2
+        overlay-script: |
+            set -eu
+            cd "${CRAFT_OVERLAY}"
+            for p in "${CRAFT_PROJECT_DIR}"/patches/*.patch; do
+              echo "Applying ${p}"
+              patch -p1 < "${p}"
+            done
 
     kubectl:
         plugin: go

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,13 +1,21 @@
 name: ceph
-base: ubuntu@26.04
-# Rockcraft edge currently needs the devel build-base for 26.04 projects.
-build-base: devel
+base: ubuntu@24.04
 version: '0.1' # replaced by CI when building to publish.
 summary: Ubuntu based Ceph container image
-description: Rock for Containerised Ceph based on Ubuntu Ceph distribution. 
+description: Rock for Containerised Ceph based on Ubuntu Ceph distribution.
 license: Apache-2.0
 platforms:
     amd64:
+
+# Tentacle (20.x) is not in Noble's main archive yet. Pull from the same
+# PPA that MicroCeph uses on core24 — it ships 20.2.0 against Noble's
+# stable Python (3.12) and python3-cryptography (~41.x), which avoids the
+# PyO3 / subinterpreter ImportError seen with Resolute's 26.04 + 3.14 +
+# python3-cryptography 46.x stack. Tracked at:
+#   https://bugs.launchpad.net/bugs/2150762
+package-repositories:
+  - type: apt
+    ppa: lmlogiudice/ceph-tentacle-noble
 
 services:
     ceph-container:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,6 +16,13 @@ platforms:
 package-repositories:
   - type: apt
     ppa: lmlogiudice/ceph-tentacle-noble
+    # Pin the PPA's signing key so craft-archives skips the launchpadlib
+    # +archive lookup. api.launchpad.net intermittently returns HTTP 503
+    # / hangs on that endpoint with no retry, wedging build-rock for
+    # ~19 minutes before failing. Pinning the fingerprint lets the build
+    # proceed when only Launchpad's web frontend is degraded.
+    # Key owner: "Launchpad PPA for Luciano Lo Giudice".
+    key-id: ADB101EC932F9AEA3800EF9E8871F59B071C7CC2
 
 services:
     ceph-container:

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -60,7 +60,7 @@ function install_apt() {
 }
 
 function bootstrap() {
-    local image="${1:missing}"
+    local image="${1:?missing}"
     local ip="${2:?missing}"
     sudo cephadm --image $image bootstrap --mon-ip $ip --single-host-defaults --skip-dashboard --skip-monitoring-stack
     df -H
@@ -71,7 +71,7 @@ function get_ip() {
 }
 
 function setupLXDMachine() {
-    sudo lxc launch --vm ubuntu:24.04 cephadm0 -c limits.cpu=4 -c limits.memory=8GiB
+    sudo lxc launch --vm ubuntu:26.04 cephadm0 -c limits.cpu=4 -c limits.memory=8GiB
     sleep 30s
 
     sudo lxc file push ./test/scripts/cephadm_helper.sh cephadm0/root/
@@ -118,17 +118,17 @@ function wait_num_objs() {
   
   for i in {1..15}; do
     num_objs=$( get_num_objs $what )
-    if [ $num_objs == $expect]; then
+    if [ "$num_objs" == "$expect" ]; then
       break
     else
       echo "$what $expect, got $num_objs..."
-      sleep 30s 
+      sleep 30s
     fi
   done
 
-  if [ $num_objs != $expect]; then
+  if [ "$num_objs" != "$expect" ]; then
     echo "Timedout waiting for $what to reach $expect count"
-    exit -1 
+    exit 1
   fi
 }
 
@@ -143,7 +143,7 @@ function test_num_objs() {
         echo "[FAIL] test_num_objs $what $expect, got $num_objs"
         echo "Ceph status"
         sudo cephadm shell -- ceph status
-        exit -1
+        exit 1
     fi
 }
 

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -2,7 +2,10 @@
 
 set -xeEo pipefail
 
-PACKAGES="cephadm openssh-server jq"
+# python3-ceph-common is a missing Depends in resolute's cephadm package:
+# cephadm 20.2.0 imports ceph.cephadm.images at startup but the package
+# only declares lvm2 + python3. Track via Launchpad bug.
+PACKAGES="cephadm openssh-server jq python3-ceph-common"
 
 function prep_docker() {
     # Run a local registry.

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -2,10 +2,13 @@
 
 set -xeEo pipefail
 
-# python3-ceph-common is a missing Depends in resolute's cephadm package:
-# cephadm 20.2.0 imports ceph.cephadm.images at startup but the package
-# only declares lvm2 + python3. Track via Launchpad bug.
-PACKAGES="cephadm openssh-server jq python3-ceph-common"
+# Workarounds for missing Depends in resolute's cephadm package:
+#  - python3-ceph-common ships the ceph.cephadm.images module that
+#    cephadm 20.2.0 imports at startup
+#  - ceph-common creates the ceph daemon user (uid/gid 64045) that
+#    cephadm bootstrap chowns its runtime dirs to
+# Tracked via https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2150665.
+PACKAGES="cephadm openssh-server jq python3-ceph-common ceph-common"
 
 function prep_docker() {
     # Run a local registry.

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -65,10 +65,45 @@ function install_apt() {
     DEBIAN_FRONTEND=noninteractive sudo apt install $PACKAGES -y 
 }
 
+function capture_bootstrap_diagnostics() {
+    # Diagnostic-only: dump mgr state and logs to help diagnose the
+    # PyO3 / "subinterpreters" failure when `mgr module enable cephadm`
+    # aborts during `cephadm bootstrap`. Does not attempt to fix anything.
+    echo "=== capture_bootstrap_diagnostics: ceph mgr module ls ==="
+    sudo cephadm shell -- ceph mgr module ls || echo "(ceph mgr module ls failed)"
+
+    echo "=== capture_bootstrap_diagnostics: cephadm ls ==="
+    sudo cephadm ls || echo "(cephadm ls failed)"
+
+    echo "=== capture_bootstrap_diagnostics: ceph-mgr daemon log files ==="
+    # /var/log/ceph/<fsid>/ceph-mgr.<host>.<rand>.log holds the Python
+    # traceback for the failed module load.
+    local mgr_logs
+    mgr_logs=$(sudo find /var/log/ceph -maxdepth 2 -type f -name 'ceph-mgr.*.log' 2>/dev/null || true)
+    if [ -n "$mgr_logs" ]; then
+        for f in $mgr_logs; do
+            echo "--- $f ---"
+            sudo cat "$f" || echo "(could not read $f)"
+        done
+    else
+        echo "(no /var/log/ceph/*/ceph-mgr.*.log files found)"
+    fi
+
+    echo "=== capture_bootstrap_diagnostics: journalctl ceph-*@mgr.* ==="
+    sudo journalctl --no-pager -n 200 -u 'ceph-*@mgr.*' || echo "(journalctl failed)"
+}
+
 function bootstrap() {
     local image="${1:?missing}"
     local ip="${2:?missing}"
-    sudo cephadm --image $image bootstrap --mon-ip $ip --single-host-defaults --skip-dashboard --skip-monitoring-stack
+    # Run cephadm bootstrap in a subshell so we can capture diagnostics on
+    # failure without losing the original non-zero exit code.
+    sudo cephadm --image "$image" bootstrap --mon-ip "$ip" --single-host-defaults --skip-dashboard --skip-monitoring-stack || {
+        rc=$?
+        echo "cephadm bootstrap failed with exit code $rc; capturing diagnostics" >&2
+        capture_bootstrap_diagnostics || true
+        exit "$rc"
+    }
     df -H
 }
 


### PR DESCRIPTION
## Summary
- move the rock recipe to Ubuntu 26.04 for Ceph Tentacle packages
- use Rockcraft latest/edge and the temporary devel build-base required by current Rockcraft 26.04 support
- add Tentacle release and edge tags for Ceph 20.x
- refresh the Rook canary stack to Rook v1.19.5, Minikube v1.38.1, and Kubernetes v1.35.0

## Validation
- confirmed Rockcraft stable fails on `base: ubuntu@26.04` with missing plugin group support
- confirmed Rockcraft edge accepts `base: ubuntu@26.04` when `build-base: devel` is set
- confirmed inside the 26.04 Rockcraft builder that `ceph-common` resolves to `20.2.0-0ubuntu2` from `resolute/main`
- audited every overlay package with `apt-cache policy`; all packages resolve on 26.04
- ran `git diff --check`, YAML parse validation, and `rockcraft expand-extensions`

## Notes
- Local `rockcraft pull pkg_info -v` on edge reached 26.04 base extraction but hung at overlay setup; package availability was validated directly inside the same builder.
- Rook current docs support Tentacle in the latest release line, and v1.19 requires Kubernetes v1.30+.