### PR TITLE
Backport Quincy package and CI fixes

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -61,9 +61,8 @@ jobs:
 
       - name: install dependencies
         run: |
-          sudo apt install skopeo
-          sudo python -m pip install --upgrade pip
-          sudo pip install flake8 pep8-naming pylxd pyyaml argparse
+          sudo apt-get update
+          sudo apt-get install -y skopeo python3-flake8 python3-pep8-naming python3-pylxd python3-yaml
 
       - name: Lint Check
         run: |
@@ -77,11 +76,11 @@ jobs:
           ls
           rock_file=$(ls *.rock | head -1)
           docker run -d -p 5000:5000 --restart=always --name registry registry:2
-          skopeo --insecure-policy copy oci-archive:$rock_file docker-daemon:canonical/ceph:latest
-          docker image ls -a
-          docker image tag canonical/ceph:latest localhost:5000/canonical/ceph:latest
           sleep 10
-          docker push localhost:5000/canonical/ceph
+          skopeo --insecure-policy copy \
+            --dest-tls-verify=false \
+            oci-archive:$rock_file \
+            docker://localhost:5000/canonical/ceph:latest
           echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
 
       - name: Deploy Cephadm over Host
@@ -117,8 +116,8 @@ jobs:
 
       - name: install dependencies
         run: |
-          sudo python -m pip install --upgrade pip
-          sudo pip install flake8 pep8-naming pylxd pyyaml argparse
+          sudo apt-get update
+          sudo apt-get install -y skopeo python3-flake8 python3-pep8-naming python3-pylxd python3-yaml
 
       - name: Lint Check
         run: |
@@ -129,11 +128,11 @@ jobs:
           ls
           rock_file=$(ls *.rock | head -1)
           docker run -d -p 5000:5000 --restart=always --name registry registry:2
-          skopeo --insecure-policy copy oci-archive:$rock_file docker-daemon:canonical/ceph:latest
-          docker image ls -a
-          docker image tag canonical/ceph:latest localhost:5000/canonical/ceph:latest
           sleep 10
-          docker push localhost:5000/canonical/ceph
+          skopeo --insecure-policy copy \
+            --dest-tls-verify=false \
+            oci-archive:$rock_file \
+            docker://localhost:5000/canonical/ceph:latest
           echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
 
       - name: install and init lxd snap
@@ -143,7 +142,15 @@ jobs:
 
       - name: clean iptables legacy
         run: |
-          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
+          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
+            sudo $ipt --flush || true
+            sudo $ipt --flush -t nat || true
+            sudo $ipt --delete-chain || true
+            sudo $ipt --delete-chain -t nat || true
+            sudo $ipt -P FORWARD ACCEPT || true
+            sudo $ipt -P INPUT ACCEPT || true
+            sudo $ipt -P OUTPUT ACCEPT || true
+          done
           sudo systemctl reload snap.lxd.daemon
           sleep 5
 
@@ -175,24 +182,39 @@ jobs:
       - name: use local disk and create partitions for osds
         run: |
           cd rook
-          ./tests/scripts/github-action-helper.sh use_local_disk
-          ./tests/scripts/github-action-helper.sh create_partitions_for_osds
+          if sudo lsblk --paths | awk '/14G/ || /64G/ { found=1 } END { exit !found }'; then
+            ./tests/scripts/github-action-helper.sh use_local_disk
+            ./tests/scripts/github-action-helper.sh create_partitions_for_osds
+          else
+            loop_devices=()
+            for i in 1 2; do
+              sudo dd if=/dev/zero of="$HOME/rook-osd-${i}.img" bs=1M seek=6144 count=0
+              loop_device="$(sudo losetup --find --show "$HOME/rook-osd-${i}.img")"
+              loop_devices+=("${loop_device##*/}")
+            done
+            printf 'ALLOW_LOOP_DEVICES=true\n' >> "$GITHUB_ENV"
+            printf -v rook_devices '%s,' "${loop_devices[@]/#/\/dev\/}"
+            printf 'ROOK_CEPH_DEVICES=%s\n' "${rook_devices%,}" >> "$GITHUB_ENV"
+            sudo lsblk
+          fi
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rock
 
       - name: Load image and load to registry
         run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
           ls
           rock_file=$(ls *.rock | head -1)
           docker run -d -p 5000:5000 --restart=always --name registry registry:2
-          skopeo --insecure-policy copy oci-archive:$rock_file docker-daemon:canonical/ceph:latest
-          docker image ls -a
-          docker image tag canonical/ceph:latest localhost:5000/canonical/ceph:latest
           sleep 10
-          docker push localhost:5000/canonical/ceph
+          skopeo --insecure-policy copy \
+            --dest-tls-verify=false \
+            oci-archive:$rock_file \
+            docker://localhost:5000/canonical/ceph:latest
           echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
 
       - name: deploy cluster

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -18,12 +18,14 @@ defaults:
 
 jobs:
   build-rock:
-    runs-on: ubuntu-latest
-    outputs:
-      rock: ${{ steps.rockcraft.outputs.rock }}
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: 5.21/stable
       - name: Prepare Rock
         uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
@@ -32,9 +34,22 @@ jobs:
           name: rock
           path: ${{ steps.rockcraft.outputs.rock }}
 
-  CephAdmScriptTest:
-    runs-on: ubuntu-latest
-    needs: build-rock
+  flake8-lint:
+    runs-on: ubuntu-22.04
+    name: Lint
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Set up Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2
+
+  CephadmTest:
+    runs-on: ubuntu-22.04
+    needs: [build-rock, flake8-lint]
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -60,80 +75,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo python3-flake8 python3-pep8-naming python3-pylxd python3-yaml
-
-      - name: Lint Check
-        run: |
-          flake8 . --count --show-source --statistics
-
-      - name: use local block device
-        run: ./test/scripts/cephadm_helper.sh use_local_disk
-
-      - name: Load image to registry
-        run: |
-          ls
-          rock_file=$(ls *.rock | head -1)
-          docker run -d -p 5000:5000 --restart=always --name registry registry:2
-          sleep 10
-          skopeo --insecure-policy copy \
-            --dest-tls-verify=false \
-            oci-archive:$rock_file \
-            docker://localhost:5000/canonical/ceph:latest
-          echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
-
-      - name: Deploy Cephadm over Host
-        run: |
-          sudo python test/deploy.py --osd-num 1 --direct-host 1 image "localhost:5000/canonical/ceph:latest"
-
-  CephAdmScriptLxdTest:
-    runs-on: ubuntu-latest
-    needs: build-rock
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-      - name: clean unrequired files.
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: rock
-
-      - name: set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo python3-flake8 python3-pep8-naming python3-pylxd python3-yaml
-
-      - name: Lint Check
-        run: |
-          flake8 . --count --show-source --statistics
-
-      - name: Load image to registry
-        run: |
-          ls
-          rock_file=$(ls *.rock | head -1)
-          docker run -d -p 5000:5000 --restart=always --name registry registry:2
-          sleep 10
-          skopeo --insecure-policy copy \
-            --dest-tls-verify=false \
-            oci-archive:$rock_file \
-            docker://localhost:5000/canonical/ceph:latest
-          echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
+        run: ./scripts/deploy-helper.sh install_custom_runner_dependencies
 
       - name: install and init lxd snap
         run: |
@@ -154,14 +96,27 @@ jobs:
           sudo systemctl reload snap.lxd.daemon
           sleep 5
 
-      - name: Deploy Cephadm over LXD Container
+      - name: Setup LXD machine
         run: |
-          reg_addr=$(./test/scripts/cephadm_helper.sh get_ip)
-          sudo python test/deploy.py --osd-num 0 --container 1 image "$reg_addr:5000/canonical/ceph:latest"
+          ./test/scripts/cephadm_helper.sh setupLXDMachine
+          ./test/scripts/cephadm_helper.sh runOnHost cephadm0 install_apt
+          ./test/scripts/cephadm_helper.sh runOnHost cephadm0 configure_insecure_registry
+
+          ./test/scripts/cephadm_helper.sh runOnHost cephadm0 deploy_cephadm localhost:5000/canonical/ceph:latest
+
+      - name: Add storage to machine
+        run: |
+          ./test/scripts/cephadm_helper.sh add_storage_devices
+
+      - name: Deploy osd service
+        run: |
+          ./test/scripts/cephadm_helper.sh runOnHost cephadm0 deploy_osd
+          ./test/scripts/cephadm_helper.sh runOnHost cephadm0 wait_num_objs osd 3
 
   RookTest:
     needs: build-rock
-    runs-on: ubuntu-latest
+    # Minikube action only works on Jammy.
+    runs-on: ubuntu-22.04
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -218,7 +173,7 @@ jobs:
           echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/containers/registries.conf
 
       - name: deploy cluster
-        run: ./scripts/deploy-helper.sh deploy_cluster
+        run: ./scripts/deploy-helper.sh deploy_cluster rook/ceph:v1.12.0 localhost:5000/canonical/ceph:latest
 
       - name: wait for prepare pod
         run: cd rook ; tests/scripts/github-action-helper.sh wait_for_prepare_pod ; sleep 100
@@ -426,7 +381,7 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: canary
-        
+
       - name: consider debugging
         uses: lhotari/action-upterm@v1
         if: failure()

--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   cla-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1

--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -25,7 +25,15 @@ jobs:
           sudo snap install lxd
           sudo snap install rockcraft --classic --edge
           sudo lxd init --auto
-          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
+          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
+            sudo $ipt --flush || true
+            sudo $ipt --flush -t nat || true
+            sudo $ipt --delete-chain || true
+            sudo $ipt --delete-chain -t nat || true
+            sudo $ipt -P FORWARD ACCEPT || true
+            sudo $ipt -P INPUT ACCEPT || true
+            sudo $ipt -P OUTPUT ACCEPT || true
+          done
           sudo systemctl reload snap.lxd.daemon
           sleep 5
 
@@ -72,4 +80,3 @@ jobs:
             docker push ghcr.io/canonical/ceph --all-tags
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
-

--- a/.github/workflows/publish_hotfix.yaml
+++ b/.github/workflows/publish_hotfix.yaml
@@ -36,7 +36,15 @@ jobs:
           sudo snap install lxd
           sudo snap install rockcraft --classic --edge
           sudo lxd init --auto
-          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
+          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
+            sudo $ipt --flush || true
+            sudo $ipt --flush -t nat || true
+            sudo $ipt --delete-chain || true
+            sudo $ipt --delete-chain -t nat || true
+            sudo $ipt -P FORWARD ACCEPT || true
+            sudo $ipt -P INPUT ACCEPT || true
+            sudo $ipt -P OUTPUT ACCEPT || true
+          done
           sudo systemctl reload snap.lxd.daemon
           sleep 5
 
@@ -83,4 +91,3 @@ jobs:
             docker push ghcr.io/canonical/ceph --all-tags
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
-

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -24,7 +24,15 @@ jobs:
           sudo snap install lxd
           sudo snap install rockcraft --classic --edge
           sudo lxd init --auto
-          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do sudo $ipt --flush; sudo $ipt --flush -t nat; sudo $ipt --delete-chain; sudo $ipt --delete-chain -t nat; sudo $ipt -P FORWARD ACCEPT; sudo $ipt -P INPUT ACCEPT; sudo $ipt -P OUTPUT ACCEPT; done
+          for ipt in iptables iptables-legacy ip6tables ip6tables-legacy; do
+            sudo $ipt --flush || true
+            sudo $ipt --flush -t nat || true
+            sudo $ipt --delete-chain || true
+            sudo $ipt --delete-chain -t nat || true
+            sudo $ipt -P FORWARD ACCEPT || true
+            sudo $ipt -P INPUT ACCEPT || true
+            sudo $ipt -P OUTPUT ACCEPT || true
+          done
           sudo systemctl reload snap.lxd.daemon
           sleep 5
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -71,6 +71,7 @@ parts:
             - ceph-volume
             - python3-asyncssh
             - python3-natsort
+            - python3-packaging
             - sharutils
             - lsof
             - etcd-client

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -37,18 +37,23 @@ parts:
             - ceph-mgr-rook
             - ceph-prometheus-alerts
             - ceph-grafana-dashboards
+            - ceph-immutable-object-cache
             - radosgw
             - nfs-ganesha
             - nfs-ganesha-ceph
+            - nfs-ganesha-rados-grace
+            - nfs-ganesha-rgw
             - cephfs-mirror
             - ceph-iscsi
             - ceph-fuse
+            - python3-rgw
             - rbd-nbd
             - rbd-mirror
             # Utilities
             - gnupg 
             - curl 
             - ca-certificates
+            - jq
             - kmod
             - lvm2
             - gdisk
@@ -113,5 +118,4 @@ parts:
             ceph.defaults : ${CRAFT_PART_INSTALL}/opt/ceph-container/etc/
             # s3cfg
             s3cfg : ${CRAFT_PART_INSTALL}/root/.s3cfg
-
 

--- a/scripts/deploy-helper.sh
+++ b/scripts/deploy-helper.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Copyright 2021 The Rook Authors. All rights reserved.
-# 
+#
 # Abridged and adapted by peter.sabaini@canonical.com
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,6 +17,14 @@
 # limitations under the License.
 
 set -xeEo pipefail
+
+function install_custom_runner_dependencies() {
+  sudo apt-get -y update
+  # for recent skopeo client
+  sudo snap install rockcraft --classic
+  sudo snap install docker
+  sleep 10
+}
 
 
 function deploy_operator_with_custom_image() {
@@ -72,8 +80,13 @@ function deploy_cluster_with_custom_image() {
 function deploy_cluster() {
   local operator_default="rook/ceph:v1.12.0"
   local operator_img=${1:-"$operator_default"}
-  local cluster_default="$( cat custom-image-spec )"
-  local cluster_img=${2:-"$cluster_default"}
+  local cluster_img
+
+  if [[ -n "${2:-}" ]]; then
+    cluster_img="$2"
+  else
+    cluster_img="$( cat custom-image-spec )"
+  fi
 
   cd rook/deploy/examples
   deploy_operator_with_custom_image operator.yaml $operator_img

--- a/scripts/deploy-helper.sh
+++ b/scripts/deploy-helper.sh
@@ -22,8 +22,13 @@ set -xeEo pipefail
 function deploy_operator_with_custom_image() {
   local yaml=${1:?missing}
   local img=${2:?missing}
+  local escaped_img="${img//\\/\\\\}"
+  escaped_img="${escaped_img//&/\\&}"
+  escaped_img="${escaped_img//|/\\|}"
+
   sed -i 's/.*ROOK_CSI_ENABLE_NFS:.*/  ROOK_CSI_ENABLE_NFS: \"true\"/g' $yaml
-  sed -i "s|image: rook/ceph:.*|image: $img|g" $yaml
+  sed -i "s|image: rook/ceph:.*|image: $escaped_img|g" $yaml
+  sed -i "s|image: .*ceph/ceph:v[0-9].*|image: $escaped_img|g" $yaml
   if [[ "$ALLOW_LOOP_DEVICES" = "true" ]]; then
     sed -i "s|ROOK_CEPH_ALLOW_LOOP_DEVICES: \"false\"|ROOK_CEPH_ALLOW_LOOP_DEVICES: \"true\"|g" $yaml
   fi
@@ -34,8 +39,33 @@ function deploy_operator_with_custom_image() {
 function deploy_cluster_with_custom_image() {
   local yaml=${1:?missing}
   local img=${2:?missing}
-  sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\//}|g" $yaml
-  sed -i "s|image: quay.io/ceph/ceph:v17.*|image: $img|g" $yaml
+  local escaped_img="${img//\\/\\\\}"
+  escaped_img="${escaped_img//&/\\&}"
+  escaped_img="${escaped_img//|/\\|}"
+
+  if [[ -n "${ROOK_CEPH_DEVICES:-}" ]]; then
+    awk -v devices="$ROOK_CEPH_DEVICES" '
+      /#deviceFilter:/ {
+        indent = substr($0, 1, index($0, "#") - 1)
+        print indent "devices:"
+        count = split(devices, device, ",")
+        for (i = 1; i <= count; i++) {
+          print indent "  - name: \"" device[i] "\""
+        }
+        next
+      }
+      { print }
+    ' "$yaml" > "$yaml.tmp"
+    mv "$yaml.tmp" "$yaml"
+  else
+    local device_filter="${BLOCK/\/dev\//}"
+    device_filter="${device_filter//\\/\\\\}"
+    device_filter="${device_filter//&/\\&}"
+    device_filter="${device_filter//|/\\|}"
+    sed -i "s|#deviceFilter:|deviceFilter: ${device_filter}|g" $yaml
+  fi
+
+  sed -i "s|image: .*ceph/ceph:v[0-9].*|image: $escaped_img|g" $yaml
   kubectl create -f $yaml
 }
 
@@ -57,7 +87,7 @@ function deploy_cluster() {
   kubectl create -f filesystem-mirror.yaml
   kubectl create -f nfs-test.yaml
   kubectl create -f subvolumegroup.yaml
-  deploy_operator_with_custom_image toolbox.yaml $img $operator_img
+  deploy_operator_with_custom_image toolbox.yaml $cluster_img
 }
 
 

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -105,25 +105,18 @@ function deploy_cephadm() {
 function deploy_osd() {
   echo "=== Pre-OSD host device state ==="
   lsblk
-  echo "=== Triggering cephadm device refresh ==="
-  sudo cephadm shell -- ceph orch device ls --refresh
-  # cephadm refreshes device inventory on a periodic timer; LXD-attached
-  # block volumes don't appear immediately. Poll for at least 3 available
-  # devices before issuing the OSD apply, to surface inventory issues
-  # earlier and avoid a silent timeout in wait_num_objs later.
+  # The Quincy orchestrator's per-host device cache is populated
+  # asynchronously and a single up-front --refresh does not block on
+  # completion. ceph-volume sees the LXD-attached block volumes
+  # immediately, but `ceph orch device ls` returns an empty list until
+  # the mgr/cephadm module pulls them in. Re-issue --refresh on each
+  # poll iteration to nudge the cache.
   local available=0
   for i in {1..20}; do
-    sleep 15
     echo "=== device inventory (attempt $i) ==="
+    sudo cephadm shell -- ceph orch device ls --refresh
+    sleep 15
     sudo cephadm shell -- ceph orch device ls
-    if [ "$i" -eq 1 ]; then
-      echo "=== diagnostic: cephadm ceph-volume inventory ==="
-      sudo cephadm ceph-volume inventory || true
-      echo "=== diagnostic: ceph orch device ls --format json-pretty (raw) ==="
-      sudo cephadm shell -- ceph orch device ls --format json-pretty || true
-      echo "=== diagnostic: ceph orch host ls ==="
-      sudo cephadm shell -- ceph orch host ls || true
-    fi
     available=$(sudo cephadm shell -- ceph orch device ls --format json-pretty 2>/dev/null \
       | jq '[.. | objects | select(has("available")) | select(.available == true)] | length' 2>/dev/null || echo 0)
     echo "available device count: ${available}"

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -116,6 +116,14 @@ function deploy_osd() {
     sleep 15
     echo "=== device inventory (attempt $i) ==="
     sudo cephadm shell -- ceph orch device ls
+    if [ "$i" -eq 1 ]; then
+      echo "=== diagnostic: cephadm ceph-volume inventory ==="
+      sudo cephadm ceph-volume inventory || true
+      echo "=== diagnostic: ceph orch device ls --format json-pretty (raw) ==="
+      sudo cephadm shell -- ceph orch device ls --format json-pretty || true
+      echo "=== diagnostic: ceph orch host ls ==="
+      sudo cephadm shell -- ceph orch host ls || true
+    fi
     available=$(sudo cephadm shell -- ceph orch device ls --format json-pretty 2>/dev/null \
       | jq '[.. | objects | select(has("available")) | select(.available == true)] | length' 2>/dev/null || echo 0)
     echo "available device count: ${available}"
@@ -123,6 +131,10 @@ function deploy_osd() {
       break
     fi
   done
+  if [ "${available}" -lt 3 ]; then
+    echo "deploy_osd: timed out waiting for >=3 available devices (last seen: ${available})" >&2
+    exit 1
+  fi
   sudo cephadm shell -- ceph orch apply osd --all-available-devices
 }
 

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -103,6 +103,26 @@ function deploy_cephadm() {
 }
 
 function deploy_osd() {
+  echo "=== Pre-OSD host device state ==="
+  lsblk
+  echo "=== Triggering cephadm device refresh ==="
+  sudo cephadm shell -- ceph orch device ls --refresh
+  # cephadm refreshes device inventory on a periodic timer; LXD-attached
+  # block volumes don't appear immediately. Poll for at least 3 available
+  # devices before issuing the OSD apply, to surface inventory issues
+  # earlier and avoid a silent timeout in wait_num_objs later.
+  local available=0
+  for i in {1..20}; do
+    sleep 15
+    echo "=== device inventory (attempt $i) ==="
+    sudo cephadm shell -- ceph orch device ls
+    available=$(sudo cephadm shell -- ceph orch device ls --format json-pretty 2>/dev/null \
+      | jq '[.. | objects | select(has("available")) | select(.available == true)] | length' 2>/dev/null || echo 0)
+    echo "available device count: ${available}"
+    if [ "${available}" -ge 3 ]; then
+      break
+    fi
+  done
   sudo cephadm shell -- ceph orch apply osd --all-available-devices
 }
 

--- a/test/scripts/cephadm_helper.sh
+++ b/test/scripts/cephadm_helper.sh
@@ -31,9 +31,19 @@ function use_local_disk() {
 }
 
 function configure_insecure_registry() {
-    echo '{"insecure-registries": []}' | sudo tee /etc/docker/daemon.json
-    jq --arg key "insecure-registries" --arg value "${1}:5000" '.[$key] += [$value]' /etc/docker/daemon.json > tmp.$$.json && sudo mv tmp.$$.json /etc/docker/daemon.json
-    sudo systemctl restart docker
+  ls
+  rock_file=$(ls *.rock | head -1)
+  docker run -d -p 5000:5000 --restart=always --name registry registry:2
+  sleep 10
+  rockcraft.skopeo --insecure-policy copy \
+    --dest-tls-verify=false \
+    oci-archive:$rock_file \
+    docker://localhost:5000/canonical/ceph:latest
+  sudo touch /etc/docker/daemon.json
+  # dont need insecure registry since it's localhost.
+  # echo $'[registries.insecure]\nregistries = ["localhost:5000"]' | sudo tee -a /etc/docker/daemon.json
+  # jq --arg key "insecure-registries" --arg value "${1}:5000" '.[$key] += [$value]' /etc/docker/daemon.json > tmp.$$.json && sudo mv tmp.$$.json /etc/docker/daemon.json
+  sudo systemctl restart docker
 }
 
 function set_cloud_archive() {
@@ -45,18 +55,44 @@ function set_cloud_archive() {
 function install_apt() {
     # Install Apt packages.
     DEBIAN_FRONTEND=noninteractive sudo apt update
-    DEBIAN_FRONTEND=noninteractive sudo apt install $PACKAGES -y 
+    DEBIAN_FRONTEND=noninteractive sudo apt install $PACKAGES -y
 }
 
 function bootstrap() {
-    local image="${1:missing}"
+    local image="${1:?missing}"
     local ip="${2:?missing}"
-    sudo cephadm --image $image bootstrap --mon-ip $ip --single-host-defaults
+    sudo cephadm --image $image bootstrap --mon-ip $ip --single-host-defaults --skip-dashboard --skip-monitoring-stack
     df -H
 }
 
 function get_ip() {
     ip -4 -j route | jq -r '.[] | select(.dst | contains("default")) | .prefsrc' | tr -d '[:space:]'
+}
+
+function setupLXDMachine() {
+    sudo lxc launch --vm ubuntu:22.04 cephadm0 -c limits.cpu=4 -c limits.memory=8GiB
+    sleep 30s
+
+    sudo lxc file push ./test/scripts/cephadm_helper.sh cephadm0/root/
+    sudo lxc file push ./*.rock cephadm0/root/
+
+    sudo lxc shell cephadm0 -- sh -c "snap install rockcraft --classic"
+}
+
+function runOnHost() {
+  local host=${1:?missing}
+  shift
+  sudo lxc shell $host -- /root/cephadm_helper.sh $@
+}
+
+function add_storage_devices() {
+  sudo lxc storage volume create default osd0 size=10GiB --type block
+  sudo lxc storage volume create default osd1 size=10GiB --type block
+  sudo lxc storage volume create default osd2 size=10GiB --type block
+
+  sudo lxc storage volume attach default osd0 cephadm0
+  sudo lxc storage volume attach default osd1 cephadm0
+  sudo lxc storage volume attach default osd2 cephadm0
 }
 
 function deploy_cephadm() {
@@ -66,15 +102,39 @@ function deploy_cephadm() {
     test_num_objs mon 1
 }
 
+function deploy_osd() {
+  sudo cephadm shell -- ceph orch apply osd --all-available-devices
+}
+
 function get_num_objs() {
-    local what=${1:?missing}   
+    local what=${1:?missing}
     sudo cephadm shell -- ceph status -f json | jq -r ".${what}map | .num_${what}s"
+}
+
+function wait_num_objs() {
+  local what=${1:?missing}
+  local expect=${2:?missing}
+
+  for i in {1..15}; do
+    num_objs=$( get_num_objs $what )
+    if [ "$num_objs" == "$expect" ]; then
+      break
+    else
+      echo "$what $expect, got $num_objs..."
+      sleep 30s
+    fi
+  done
+
+  if [ "$num_objs" != "$expect" ]; then
+    echo "Timedout waiting for $what to reach $expect count"
+    exit 1
+  fi
 }
 
 function test_num_objs() {
     local what=${1:?missing}
     local expect=${2:?missing}
-    
+
     num_objs=$( get_num_objs $what )
     if [ $num_objs == $expect ]; then
         echo "[OK] test_num_objs $what $expect"
@@ -82,7 +142,7 @@ function test_num_objs() {
         echo "[FAIL] test_num_objs $what $expect, got $num_objs"
         echo "Ceph status"
         sudo cephadm shell -- ceph status
-        exit -1
+        exit 1
     fi
 }
 


### PR DESCRIPTION
## Summary
- add Quincy-available packages that were missing from the rock: ceph-immutable-object-cache, nfs-ganesha-rados-grace, nfs-ganesha-rgw, python3-rgw, and jq
- switch canary test dependencies from pip installs to apt packages
- copy test rocks directly from OCI archive to the local registry with skopeo
- tolerate busy iptables cleanup in CI/release workflows
- add Rook loop-device fallback and fix Rook image substitution/toolbox image handling

## Validation
- confirmed on a Jammy package-check container that all added packages resolve from apt
- confirmed ghcr.io/canonical/ceph:quincy-edge has no ceph=True label today
- confirmed Jammy cephadm 17.2.x can run `cephadm --image ghcr.io/canonical/ceph:quincy-edge version` against the unlabeled image
- confirmed a Jammy VM single-host bootstrap completes with the unlabeled quincy-edge image
- ran `git diff --check`, YAML parse validation, `bash -n` on touched shell helpers, and `rockcraft expand-extensions`

## Notes
- This intentionally does not backport the OCI ceph=True label machinery; Quincy cephadm accepts the current unlabeled image.